### PR TITLE
refactor(electron): rework the bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Uses Tauri's event system and commands, respecting its security model where main
 - [vitordino/reduxtron](https://github.com/vitordino/reduxtron) (Electron + Redux + Zustand)
 
   - Redux store in the main process, optionally synced to Zustand in the renderer
-  - Reduxtron is the original inspiration for `@zubridge/electron` (and Zutron)
+  - Reduxtron is the original inspiration for Zutron (and hence `@zubridge/electron`)
 
 - [klarna/electron-redux](https://github.com/klarna/electron-redux) (Electron + Redux)
   - Bi-directional sync between one Redux store in the main process, and another in the renderer

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ Uses Tauri's event system and commands, respecting its security model where main
 - [goosewobbler/zutron](https://github.com/goosewobbler/zutron) (Electron + Zustand)
 
   - Zustand store in the main process, synced to Zustand in the renderer
-  - `@zubridge/electron` started as a rebrand of Zutron but has since evolved
+  - `@zubridge/electron` started as a rebrand of Zutron and evolved from there
 
 - [vitordino/reduxtron](https://github.com/vitordino/reduxtron) (Electron + Redux + Zustand)
 
   - Redux store in the main process, optionally synced to Zustand in the renderer
-  - `@zubridge/electron` (as Zutron) was originally based on Reduxtron
+  - Reduxtron is the original inspiration for `@zubridge/electron` (and Zutron)
 
 - [klarna/electron-redux](https://github.com/klarna/electron-redux) (Electron + Redux)
   - Bi-directional sync between one Redux store in the main process, and another in the renderer

--- a/apps/electron-example/package.json
+++ b/apps/electron-example/package.json
@@ -1,14 +1,14 @@
 {
   "name": "zubridge-electron-example",
   "version": "1.0.0-next.1",
-  "description": "An application demonstrating all three approaches of using zubridge with Electron: basic, handlers, and reducers",
+  "description": "An application demonstrating all approaches of using zubridge with Electron",
   "main": "./out-basic/main/index.js",
   "type": "module",
   "author": "goosewobbler",
   "homepage": "https://github.com/goosewobbler/zubridge",
   "scripts": {
     "clean": "pnpm clean:output && pnpm dlx shx rm -rf ./node_modules pnpm-lock.yaml",
-    "clean:output": "pnpm dlx shx rm -rf ./dist* ./out*",
+    "clean:output": "pnpm dlx shx rm -rf ./dist* ./out* .cache",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",

--- a/apps/electron-example/package.json
+++ b/apps/electron-example/package.json
@@ -24,7 +24,7 @@
     "start:compiled:reducers": "cross-env NODE_ENV=production ELECTRON_IS_DEV=0 electron ./out-reducers/main/index.js",
     "start:compiled:redux": "cross-env NODE_ENV=production ELECTRON_IS_DEV=0 electron ./out-redux/main/index.js",
     "start:compiled:custom": "cross-env NODE_ENV=production ELECTRON_IS_DEV=0 electron ./out-custom/main/index.js",
-    "dev": "electron-vite dev",
+    "dev": "pnpm dev:basic",
     "dev:basic": "cross-env ZUBRIDGE_MODE=basic ELECTRON_ENTRY=./out-basic/main/index.js electron-vite dev",
     "dev:handlers": "cross-env ZUBRIDGE_MODE=handlers ELECTRON_ENTRY=./out-handlers/main/index.js electron-vite dev",
     "dev:reducers": "cross-env ZUBRIDGE_MODE=reducers ELECTRON_ENTRY=./out-reducers/main/index.js electron-vite dev",

--- a/apps/electron-example/src/main/bridge.ts
+++ b/apps/electron-example/src/main/bridge.ts
@@ -1,17 +1,18 @@
-import { BrowserWindow } from 'electron';
+import { WebContents } from 'electron';
 import type { StoreApi } from 'zustand';
 import type { ZustandBridge } from '@zubridge/electron/main';
 import type { Store as ReduxStore } from 'redux';
 
 import { getZubridgeMode } from '../utils/mode.js';
 import type { BaseState } from '../types/index.js';
+import { WebContentsWrapper } from '@zubridge/types';
 
 /**
  * Creates the appropriate bridge implementation based on the selected mode
  */
 export const createBridge = async <S extends BaseState, Store extends StoreApi<S>>(
   store: Store | ReduxStore,
-  windows: BrowserWindow[],
+  windows: (WebContentsWrapper | WebContents)[],
 ): Promise<ZustandBridge> => {
   const mode = getZubridgeMode();
   console.log(`[Main] Using Zubridge mode: ${mode}`);

--- a/apps/electron-example/src/main/index.ts
+++ b/apps/electron-example/src/main/index.ts
@@ -35,7 +35,7 @@ debug(`Test mode: ${isTestMode}`);
 const icon = path.join(__dirname, '..', '..', 'resources', 'images', 'icon.png');
 
 // Disable GPU acceleration
-if (process.platform === 'darwin') {
+if (!isTestMode && process.platform === 'darwin') {
   app.disableHardwareAcceleration();
   app.commandLine.appendSwitch('disable-gpu');
 }

--- a/apps/electron-example/src/main/index.ts
+++ b/apps/electron-example/src/main/index.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import process from 'node:process';
-import { BrowserWindow, app, ipcMain } from 'electron';
+import { BrowserWindow, WebContents, app, ipcMain } from 'electron';
 
-import { isDev } from '@zubridge/electron';
+import { isDev, WebContentsWrapper } from '@zubridge/electron';
 import 'wdio-electron-service/main';
 
 import { store, initStore } from './store.js';
@@ -105,7 +105,7 @@ app
     debug('Creating bridge with windows');
 
     // Use a more general array that accepts different window/view types
-    const windowsAndViews: any[] = [];
+    const windowsAndViews: Array<WebContentsWrapper | WebContents> = [];
 
     if (initialMainWindow) {
       debug(`Adding main window ID: ${initialMainWindow.id}`);

--- a/apps/electron-example/src/main/index.ts
+++ b/apps/electron-example/src/main/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import process from 'node:process';
-import { BrowserWindow, app, ipcMain, webContents } from 'electron';
+import { BrowserWindow, app, ipcMain } from 'electron';
 
 import { isDev } from '@zubridge/electron';
 import 'wdio-electron-service/main';
@@ -29,12 +29,6 @@ const isDevMode = await isDev();
 debug(`Dev mode: ${isDevMode}`);
 
 const icon = path.join(__dirname, '..', '..', 'resources', 'images', 'icon.png');
-
-// Disable GPU acceleration
-if (isDevMode) {
-  app.disableHardwareAcceleration();
-  app.commandLine.appendSwitch('disable-gpu');
-}
 
 const mode = getZubridgeMode();
 const modeName = getModeName();
@@ -75,11 +69,11 @@ app
     debug(`Direct WebContents window created with ID: ${initialDirectWebContentsWindow.id}`);
 
     debug('Initializing BrowserView window');
-    const { window: initialBrowserViewWindow, browserView } = windows.initBrowserViewWindow();
+    const { browserView } = windows.initBrowserViewWindow();
     debug(`BrowserView WebContents ID: ${browserView?.webContents.id}`);
 
     debug('Initializing WebContentsView window');
-    const { window: initialWebContentsViewWindow, webContentsView } = windows.initWebContentsViewWindow();
+    const { webContentsView } = windows.initWebContentsViewWindow();
     debug(`WebContentsView WebContents ID: ${webContentsView?.webContents.id}`);
 
     // Initialize the store

--- a/apps/electron-example/src/main/index.ts
+++ b/apps/electron-example/src/main/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import process from 'node:process';
-import { BrowserWindow, type BrowserWindowConstructorOptions, app, ipcMain } from 'electron';
+import { BrowserWindow, app, ipcMain, webContents } from 'electron';
 
 import { isDev } from '@zubridge/electron';
 import 'wdio-electron-service/main';
@@ -10,169 +10,45 @@ import { tray } from './tray/index.js';
 import { createBridge } from './bridge.js';
 import { getModeName, getZubridgeMode } from '../utils/mode.js';
 import { getPreloadPath } from '../utils/path.js';
+import * as windows from './window.js';
+
+// Debug logger
+function debug(message: string) {
+  const timestamp = new Date().toISOString();
+  console.log(`[DEBUG ${timestamp}] ${message}`);
+}
+
+debug('Starting app initialization');
 
 // Ensure NODE_ENV is always set
 process.env.NODE_ENV = process.env.NODE_ENV || (app.isPackaged ? 'production' : 'development');
 
 // Check if we're in development mode using the shared utility
+debug('Checking dev mode');
 const isDevMode = await isDev();
+debug(`Dev mode: ${isDevMode}`);
 
 const icon = path.join(__dirname, '..', '..', 'resources', 'images', 'icon.png');
 
+// Disable GPU acceleration
+if (isDevMode) {
+  app.disableHardwareAcceleration();
+  app.commandLine.appendSwitch('disable-gpu');
+}
+
 const mode = getZubridgeMode();
 const modeName = getModeName();
+debug(`Using Zubridge mode: ${modeName}`);
 
 // Ensure we always use the absolute path for the preload script
 const preloadPath = getPreloadPath(__dirname);
-console.log('Using preload path:', preloadPath);
-
-const windowOptions: BrowserWindowConstructorOptions = {
-  show: false,
-  icon,
-  title: `Zubridge Electron Example (${modeName}) - Main Window`,
-  width: 800,
-  height: 600,
-  webPreferences: {
-    contextIsolation: true,
-    scrollBounce: true,
-    sandbox: true,
-    nodeIntegration: false,
-    preload: preloadPath,
-  },
-};
+debug(`Using preload path: ${preloadPath}`);
 
 // Flag to track when app is explicitly being quit
 let isAppQuitting = false;
 
-// Keep track of the main window and the secondary window
-let mainWindow: BrowserWindow | null = null;
-let secondaryWindow: BrowserWindow | null = null;
-// Track runtime windows that need cleanup
-const runtimeWindows: BrowserWindow[] = [];
-
-function initMainWindow(): BrowserWindow {
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.show();
-    return mainWindow;
-  }
-
-  mainWindow = new BrowserWindow({
-    ...windowOptions,
-    title: `Zubridge Electron Example (${modeName}) - Main Window`,
-  });
-
-  mainWindow.setTitle(`Zubridge Electron Example (${modeName}) - Main Window`);
-  console.log('Set main window title:', mainWindow.getTitle());
-
-  if (isDevMode) {
-    mainWindow.loadURL('http://localhost:5173/');
-  } else {
-    const htmlPath = path.join(__dirname, '..', 'renderer', 'index.html');
-    mainWindow.loadFile(htmlPath);
-  }
-
-  mainWindow.on('ready-to-show', () => {
-    mainWindow?.show();
-  });
-
-  mainWindow.on('close', (event) => {
-    if (isAppQuitting || (secondaryWindow && !secondaryWindow.isDestroyed())) {
-      mainWindow = null; // Allow GC
-      return; // Allow closing if quitting or other primary window exists
-    }
-    event.preventDefault();
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.hide();
-    }
-  });
-
-  return mainWindow;
-}
-
-// Function to initialize the secondary window
-function initSecondaryWindow(): BrowserWindow {
-  if (secondaryWindow && !secondaryWindow.isDestroyed()) {
-    secondaryWindow.show();
-    return secondaryWindow;
-  }
-
-  secondaryWindow = new BrowserWindow({
-    ...windowOptions, // Use base options
-    title: `Zubridge Electron Example (${modeName}) - Secondary Window`, // Specific title
-    width: 700, // Different size
-    height: 500,
-    x: windowOptions.x ? windowOptions.x + 50 : 100, // Offset position
-    y: windowOptions.y ? windowOptions.y + 50 : 100,
-  });
-
-  secondaryWindow.setTitle(`Zubridge Electron Example (${modeName}) - Secondary Window`);
-
-  if (isDevMode) {
-    secondaryWindow.loadURL('http://localhost:5173/');
-    // Optionally open DevTools for the second window too
-    // secondaryWindow.webContents.openDevTools();
-  } else {
-    const htmlPath = path.join(__dirname, '..', 'renderer', 'index.html');
-    secondaryWindow.loadFile(htmlPath);
-  }
-
-  secondaryWindow.on('ready-to-show', () => {
-    secondaryWindow?.show(); // Use optional chaining
-  });
-
-  // Allow secondary window to close normally, but nullify reference
-  secondaryWindow.on('close', () => {
-    secondaryWindow = null;
-  });
-
-  return secondaryWindow;
-}
-
-// Function to create a new runtime window
-function createRuntimeWindow(): BrowserWindow {
-  const runtimeWindow = new BrowserWindow({
-    ...windowOptions, // Use base options
-    width: 450, // Maybe different size for runtime
-    height: 350,
-    title: `Zubridge Electron Example (${modeName}) - Runtime Window`,
-    // Ensure webPreferences are set correctly!
-    webPreferences: {
-      ...windowOptions.webPreferences, // Inherit base prefs (includes preload)
-      // any runtime-specific overrides?
-    },
-  });
-
-  // Track this window
-  runtimeWindows.push(runtimeWindow);
-  console.log(`Runtime window ${runtimeWindow.id} created and tracked.`);
-
-  if (isDevMode) {
-    runtimeWindow.loadURL('http://localhost:5173/');
-    // Optionally open DevTools
-    // runtimeWindow.webContents.openDevTools();
-  } else {
-    const htmlPath = path.join(__dirname, '..', 'renderer', 'index.html');
-    runtimeWindow.loadFile(htmlPath);
-  }
-
-  runtimeWindow.on('ready-to-show', () => {
-    runtimeWindow.show();
-  });
-
-  // Important: Clean up from runtimeWindows array when closed
-  runtimeWindow.once('closed', () => {
-    const index = runtimeWindows.findIndex((w) => w.id === runtimeWindow.id);
-    if (index !== -1) {
-      runtimeWindows.splice(index, 1);
-      console.log(`Runtime window ${runtimeWindow.id} removed from tracking.`);
-    }
-    // Note: bridge subscription cleanup is handled by trackNewWindows listener
-  });
-
-  return runtimeWindow;
-}
-
 app.on('window-all-closed', () => {
+  debug('All windows closed event');
   if (process.platform !== 'darwin') {
     isAppQuitting = true;
     app.quit();
@@ -180,219 +56,355 @@ app.on('window-all-closed', () => {
 });
 
 app.on('before-quit', () => {
+  debug('App before-quit event');
   isAppQuitting = true;
 });
 
 app
   .whenReady()
   .then(async () => {
+    debug('App is ready, initializing windows');
+
+    // Initialize all windows
+    debug('Initializing main window');
+    const initialMainWindow = windows.initMainWindow(isAppQuitting);
+    debug(`Main window created with ID: ${initialMainWindow.id}`);
+
+    debug('Initializing direct WebContents window');
+    const initialDirectWebContentsWindow = windows.initDirectWebContentsWindow();
+    debug(`Direct WebContents window created with ID: ${initialDirectWebContentsWindow.id}`);
+
+    debug('Initializing BrowserView window');
+    const { window: initialBrowserViewWindow, browserView } = windows.initBrowserViewWindow();
+    debug(`BrowserView WebContents ID: ${browserView?.webContents.id}`);
+
+    debug('Initializing WebContentsView window');
+    const { window: initialWebContentsViewWindow, webContentsView } = windows.initWebContentsViewWindow();
+    debug(`WebContentsView WebContents ID: ${webContentsView?.webContents.id}`);
+
     // Initialize the store
+    debug('Initializing store');
     await initStore();
+    debug('Store initialized');
 
-    // Create both windows
-    const initialMainWindow = initMainWindow();
-    const initialSecondaryWindow = initSecondaryWindow();
+    // Create the bridge, passing all windows/views for synchronization
+    debug('Creating bridge with windows');
 
-    // Create the bridge, passing both initial windows for synchronization
-    const bridge = await createBridge(store, [initialMainWindow, initialSecondaryWindow]);
+    // Use a more general array that accepts different window/view types
+    const windowsAndViews: any[] = [];
 
-    // Initialize the system tray - pass main window for potential interaction logic
-    const trayInstance = tray(store, initialMainWindow);
+    if (initialMainWindow) {
+      debug(`Adding main window ID: ${initialMainWindow.id}`);
+      windowsAndViews.push(initialMainWindow);
+    }
 
-    // Get the subscribe function from the bridge
-    const { subscribe } = bridge;
+    if (initialDirectWebContentsWindow) {
+      debug(`Adding direct WebContents window ID: ${initialDirectWebContentsWindow.id}`);
+      windowsAndViews.push(initialDirectWebContentsWindow);
+    }
 
-    // On macOS activate, ensure both primary windows are handled
-    app.on('activate', () => {
-      // Use optional chaining and null checks
-      const hasMainWindow = mainWindow && !mainWindow.isDestroyed();
-      const hasSecondaryWindow = secondaryWindow && !secondaryWindow.isDestroyed();
+    if (browserView) {
+      debug(`Adding browserView directly, WebContents ID: ${browserView.webContents.id}`);
+      windowsAndViews.push(browserView);
+    }
 
-      let windowToFocus: BrowserWindow | null = null;
+    if (webContentsView) {
+      debug(`Adding webContentsView directly, WebContents ID: ${webContentsView.webContents.id}`);
+      windowsAndViews.push(webContentsView);
+    }
 
-      if (!hasMainWindow) {
-        const newMainWindow = initMainWindow();
-        subscribe([newMainWindow]); // Subscribe new main window
-        windowToFocus = newMainWindow;
-      } else if (!mainWindow?.isVisible()) {
-        mainWindow?.show();
-        windowToFocus = mainWindow;
-      } else {
-        windowToFocus = mainWindow;
-      }
+    debug(`Passing ${windowsAndViews.length} windows/views to bridge`);
 
-      if (!hasSecondaryWindow) {
-        const newSecondaryWindow = initSecondaryWindow();
-        subscribe([newSecondaryWindow]);
-      } else if (!secondaryWindow?.isVisible()) {
-        secondaryWindow?.show();
-      }
+    try {
+      debug('Before bridge creation');
+      const bridge = await createBridge(store, windowsAndViews);
+      debug('Bridge created successfully');
 
-      // Focus the determined window (use optional chaining)
-      windowToFocus?.focus();
-    });
+      // Create the system tray
+      debug('Creating system tray');
+      const trayInstance = tray(store, initialMainWindow);
+      debug('System tray created');
 
-    // Function to track and subscribe new windows to the bridge
-    const trackNewWindows = () => {
-      try {
-        const allWindows = BrowserWindow.getAllWindows();
-        for (const win of allWindows) {
-          // Ensure we skip mainWindow and secondaryWindow correctly
-          if (!win || win.isDestroyed() || win === mainWindow || win === secondaryWindow) {
-            continue;
-          }
+      // Get the subscribe function from the bridge
+      const { subscribe } = bridge;
+      debug('Retrieved subscribe function from bridge');
 
-          const isTracked = runtimeWindows.some((w) => w === win);
-          if (!isTracked) {
-            runtimeWindows.push(win);
-            const subscription = subscribe([win]);
-            win.once('closed', () => {
-              const index = runtimeWindows.indexOf(win);
-              if (index !== -1) runtimeWindows.splice(index, 1);
-              subscription.unsubscribe();
-              console.log(`Window ${win.id} closed and unsubscribed`);
-            });
-          }
+      // On macOS activate, ensure all primary windows are handled
+      app.on('activate', () => {
+        debug('App activate event triggered');
+        const { mainWindow, directWebContentsWindow, browserViewWindow, webContentsViewWindow } =
+          windows.getWindowRefs();
+
+        // Use optional chaining and null checks
+        const hasMainWindow = mainWindow && !mainWindow.isDestroyed();
+        const hasDirectWebContentsWindow = directWebContentsWindow && !directWebContentsWindow.isDestroyed();
+        const hasBrowserViewWindow = browserViewWindow && !browserViewWindow.isDestroyed();
+        const hasWebContentsViewWindow = webContentsViewWindow && !webContentsViewWindow.isDestroyed();
+
+        debug(
+          `Window states - Main: ${hasMainWindow}, Direct: ${hasDirectWebContentsWindow}, BrowserView: ${hasBrowserViewWindow}, WebContentsView: ${hasWebContentsViewWindow}`,
+        );
+
+        let windowToFocus: BrowserWindow | undefined = undefined;
+
+        if (!hasMainWindow) {
+          debug('Creating new main window on activate');
+          const newMainWindow = windows.initMainWindow(isAppQuitting);
+          subscribe([newMainWindow]); // Subscribe new main window
+          windowToFocus = newMainWindow;
+        } else if (!mainWindow?.isVisible()) {
+          debug('Showing existing main window');
+          mainWindow?.show();
+          windowToFocus = mainWindow;
+        } else {
+          windowToFocus = mainWindow;
         }
 
-        // Clean up destroyed windows from runtimeWindows
-        for (let i = runtimeWindows.length - 1; i >= 0; i--) {
-          if (runtimeWindows[i]?.isDestroyed()) {
-            // Optional chaining for safety
-            runtimeWindows.splice(i, 1);
-          }
+        if (!hasDirectWebContentsWindow) {
+          debug('Creating new direct WebContents window on activate');
+          const newDirectWebContentsWindow = windows.initDirectWebContentsWindow();
+          subscribe([newDirectWebContentsWindow]);
+        } else if (!directWebContentsWindow?.isVisible()) {
+          debug('Showing existing direct WebContents window');
+          directWebContentsWindow?.show();
         }
-      } catch (error) {
-        console.error('Error tracking windows:', error);
-      }
-    };
 
-    // Run the tracker when the app starts
-    trackNewWindows();
-
-    // Poll for new windows every second to catch any windows created by child windows
-    const windowTrackingInterval = setInterval(trackNewWindows, 1000);
-
-    // Modify quit handler to clean up both windows if they exist
-    app.on('quit', () => {
-      try {
-        clearInterval(windowTrackingInterval);
-        trayInstance.destroy();
-        bridge.unsubscribe();
-
-        // Close runtime windows
-        runtimeWindows.forEach((window) => {
-          if (window && !window.isDestroyed()) {
-            window.removeAllListeners('closed'); // Prevent listener leaks
-            window.close();
+        if (!hasBrowserViewWindow) {
+          debug('Creating new BrowserView window on activate');
+          const { browserView } = windows.initBrowserViewWindow();
+          // Pass the browserView directly to subscribe
+          if (browserView) {
+            debug(`Subscribing BrowserView directly, WebContents ID: ${browserView.webContents.id}`);
+            subscribe([browserView]);
           }
-        });
-        runtimeWindows.length = 0;
+        } else if (!browserViewWindow?.isVisible()) {
+          debug('Showing existing BrowserView window');
+          browserViewWindow?.show();
+        }
 
-        // Explicitly destroy main and secondary if they weren't closed
-        if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
-        if (secondaryWindow && !secondaryWindow.isDestroyed()) secondaryWindow.destroy();
-      } catch (error) {
-        console.error('Error during cleanup:', error);
-      }
-    });
+        if (!hasWebContentsViewWindow) {
+          debug('Creating new WebContentsView window on activate');
+          const { webContentsView } = windows.initWebContentsViewWindow();
+          // Pass the webContentsView directly to subscribe
+          if (webContentsView) {
+            debug(`Subscribing WebContentsView directly, WebContents ID: ${webContentsView.webContents.id}`);
+            subscribe([webContentsView]);
+          }
+        } else if (!webContentsViewWindow?.isVisible()) {
+          debug('Showing existing WebContentsView window');
+          webContentsViewWindow?.show();
+        }
 
-    app.focus({ steal: true });
-    mainWindow?.focus();
+        // Focus the determined window (use optional chaining)
+        debug(`Focusing window ID: ${windowToFocus?.id}`);
+        windowToFocus?.focus();
+      });
 
-    // Set up the handler for closeCurrentWindow
-    ipcMain.handle('closeCurrentWindow', async (event) => {
-      try {
-        // Get the window that sent this message
-        const window = BrowserWindow.fromWebContents(event.sender);
+      // Function to track and subscribe new windows to the bridge
+      const trackNewWindows = () => {
+        try {
+          // debug('Tracking new windows');
+          const { mainWindow, directWebContentsWindow, browserViewWindow, webContentsViewWindow, runtimeWindows } =
+            windows.getWindowRefs();
+          const allWindows = BrowserWindow.getAllWindows();
 
-        if (window) {
-          // If this is the main window, just minimize it
-          if (window === mainWindow) {
-            if (!window.isDestroyed()) {
-              window.minimize();
+          // debug(`Found ${allWindows.length} total windows, ${runtimeWindows.length} runtime windows`);
+
+          for (const win of allWindows) {
+            // Ensure we skip non-Runtime windows correctly
+            if (
+              !win ||
+              win.isDestroyed() ||
+              win === mainWindow ||
+              win === directWebContentsWindow ||
+              win === browserViewWindow ||
+              win === webContentsViewWindow
+            ) {
+              continue;
             }
-          } else {
-            // Common close logic for all modes
-            console.log(`Closing window ${window.id}`);
 
-            // In all modes, just close the window directly
-            window.isFocused() && window.close();
+            const isTracked = runtimeWindows.some((w) => w === win);
+            if (!isTracked) {
+              debug(`Adding new runtime window ${win.id} to tracking`);
+              runtimeWindows.push(win);
+              const subscription = subscribe([win]);
+              win.once('closed', () => {
+                debug(`Runtime window ${win.id} closed, cleaning up`);
+                const index = runtimeWindows.indexOf(win);
+                if (index !== -1) runtimeWindows.splice(index, 1);
+                subscription.unsubscribe();
+                debug(`Window ${win.id} closed and unsubscribed`);
+              });
+            }
           }
+
+          // Clean up destroyed windows from runtimeWindows
+          for (let i = runtimeWindows.length - 1; i >= 0; i--) {
+            if (runtimeWindows[i]?.isDestroyed()) {
+              // Optional chaining for safety
+              debug(`Removing destroyed window from runtimeWindows array at index ${i}`);
+              runtimeWindows.splice(i, 1);
+            }
+          }
+        } catch (error) {
+          console.error('Error tracking windows:', error);
         }
-        return true;
-      } catch (error) {
-        console.error('Error handling closeCurrentWindow:', error);
-        return false;
-      }
-    });
-
-    // Set up handler for window-created event
-    ipcMain.handle('window-created', (_event) => {
-      // Immediately track the new window
-      trackNewWindows();
-      return true;
-    });
-
-    // Set up handler to check if the window is the main window
-    ipcMain.handle('is-main-window', (event) => {
-      const window = BrowserWindow.fromWebContents(event.sender);
-      // Check if this is the main window
-      return window === mainWindow;
-    });
-
-    // Set up handler to get the window ID
-    ipcMain.handle('get-window-id', (event) => {
-      const window = BrowserWindow.fromWebContents(event.sender);
-      return window ? window.id : null;
-    });
-
-    // Set up handler to get window type (main, secondary, runtime) and ID
-    ipcMain.handle('get-window-info', (event) => {
-      const window = BrowserWindow.fromWebContents(event.sender);
-      if (!window) {
-        return null;
-      }
-      const windowId = window.id;
-      let windowType: 'main' | 'secondary' | 'runtime' = 'runtime'; // Default to runtime
-
-      if (window === mainWindow) {
-        windowType = 'main';
-      } else if (window === secondaryWindow) {
-        windowType = 'secondary';
-      }
-      // No need to check runtimeWindows array explicitly, default handles it
-
-      return { type: windowType, id: windowId };
-    });
-
-    // --> NEW: IPC Handler for creating runtime windows <--
-    ipcMain.handle('create-runtime-window', (event) => {
-      console.log(`IPC: Received request to create runtime window from sender ${event.sender.id}`);
-      const newWindow = createRuntimeWindow();
-      // Subscribe the new window immediately
-      subscribe([newWindow]);
-      return { success: true, windowId: newWindow.id };
-    });
-    // --> END NEW HANDLER <--
-
-    // Set up handler to get the current mode
-    ipcMain.handle('get-mode', () => {
-      return {
-        mode,
-        modeName,
       };
-    });
 
-    // Set up handler to quit the app
-    ipcMain.handle('quitApp', () => {
-      isAppQuitting = true;
-      app.quit();
-      return true;
-    });
+      // Run the tracker when the app starts
+      debug('Running initial window tracker');
+      trackNewWindows();
+
+      // Poll for new windows every second to catch any windows created by child windows
+      debug('Setting up window tracking interval');
+      const windowTrackingInterval = setInterval(trackNewWindows, 1000);
+
+      // Modify quit handler to clean up both windows if they exist
+      app.on('quit', () => {
+        debug('App quit event triggered');
+        try {
+          debug('Cleaning up resources on quit');
+          clearInterval(windowTrackingInterval);
+          trayInstance.destroy();
+          bridge.unsubscribe();
+
+          // Clean up all windows
+          debug('Cleaning up windows');
+          windows.cleanupWindows();
+          debug('Windows cleanup complete');
+        } catch (error) {
+          console.error('Error during cleanup:', error);
+        }
+      });
+
+      debug('Setting initial window focus');
+      app.focus({ steal: true });
+      const { mainWindow } = windows.getWindowRefs();
+      mainWindow?.focus();
+
+      // Set up the handler for closeCurrentWindow
+      debug('Setting up IPC handlers');
+      ipcMain.handle('closeCurrentWindow', async (event) => {
+        debug(`CloseCurrentWindow request received from window ID: ${event.sender.id}`);
+        try {
+          // Get the window that sent this message
+          const window = BrowserWindow.fromWebContents(event.sender);
+          const { mainWindow } = windows.getWindowRefs();
+
+          if (window) {
+            // If this is the main window, just minimize it
+            if (window === mainWindow) {
+              debug('Minimizing main window instead of closing');
+              if (!window.isDestroyed()) {
+                window.minimize();
+              }
+            } else {
+              // Common close logic for all modes
+              debug(`Closing window ${window.id}`);
+
+              // In all modes, just close the window directly
+              window.isFocused() && window.close();
+            }
+          }
+          return true;
+        } catch (error) {
+          console.error('Error handling closeCurrentWindow:', error);
+          return false;
+        }
+      });
+
+      // Set up handler for window-created event
+      ipcMain.handle('window-created', (_event) => {
+        debug('Window created event received');
+        // Immediately track the new window
+        trackNewWindows();
+        return true;
+      });
+
+      // Set up handler to check if the window is the main window
+      ipcMain.handle('is-main-window', (event) => {
+        const window = BrowserWindow.fromWebContents(event.sender);
+        const { mainWindow } = windows.getWindowRefs();
+        // Check if this is the main window
+        const isMainWindow = window === mainWindow;
+        debug(`is-main-window check for window ${event.sender.id}: ${isMainWindow}`);
+        return isMainWindow;
+      });
+
+      // Set up handler to get the window ID
+      ipcMain.handle('get-window-id', (event) => {
+        const window = BrowserWindow.fromWebContents(event.sender);
+        const windowId = window ? window.id : null;
+        debug(`get-window-id for ${event.sender.id}: ${windowId}`);
+        return windowId;
+      });
+
+      // Set up handler to get window type (main, secondary, runtime) and ID
+      ipcMain.handle('get-window-info', (event) => {
+        const window = BrowserWindow.fromWebContents(event.sender);
+        if (!window) {
+          debug(`get-window-info: No window found for ${event.sender.id}`);
+          return null;
+        }
+
+        const { mainWindow, directWebContentsWindow, browserViewWindow, webContentsViewWindow } =
+          windows.getWindowRefs();
+        const windowId = window.id;
+        let windowType: 'main' | 'directWebContents' | 'browserView' | 'webContentsView' | 'runtime' = 'runtime'; // Default to runtime
+
+        if (window === mainWindow) {
+          windowType = 'main';
+        } else if (window === directWebContentsWindow) {
+          windowType = 'directWebContents';
+        } else if (window === browserViewWindow) {
+          windowType = 'browserView';
+        } else if (window === webContentsViewWindow) {
+          windowType = 'webContentsView';
+        }
+        // No need to check runtimeWindows array explicitly, default handles it
+
+        debug(`get-window-info for ${event.sender.id}: type=${windowType}, id=${windowId}`);
+        return { type: windowType, id: windowId };
+      });
+
+      // --> NEW: IPC Handler for creating runtime windows <--
+      ipcMain.handle('create-runtime-window', (event) => {
+        debug(`create-runtime-window request from ${event.sender.id}`);
+        console.log(`IPC: Received request to create runtime window from sender ${event.sender.id}`);
+        const newWindow = windows.createRuntimeWindow();
+        // Subscribe the new window immediately
+        debug(`Runtime window created with ID: ${newWindow.id}, subscribing to bridge`);
+        subscribe([newWindow]);
+        return { success: true, windowId: newWindow.id };
+      });
+      // --> END NEW HANDLER <--
+
+      // Set up handler to get the current mode
+      ipcMain.handle('get-mode', () => {
+        debug(`get-mode request, returning: ${mode}, ${modeName}`);
+        return {
+          mode,
+          modeName,
+        };
+      });
+
+      // Set up handler to quit the app
+      ipcMain.handle('quitApp', () => {
+        debug('quitApp request received, setting isAppQuitting flag');
+        isAppQuitting = true;
+        app.quit();
+        return true;
+      });
+
+      debug('App initialization complete, waiting for events');
+    } catch (error) {
+      console.error('Error creating bridge:', error);
+      debug(`CRITICAL ERROR creating bridge: ${error}`);
+    }
   })
   .catch((error) => {
     console.error('Error during app initialization:', error);
+    debug(`CRITICAL ERROR during app initialization: ${error}`);
   });
 
 // For testing and debugging

--- a/apps/electron-example/src/main/tray/base.ts
+++ b/apps/electron-example/src/main/tray/base.ts
@@ -66,67 +66,61 @@ export class BaseSystemTray {
         this.window.focus();
       }
     };
-    const stateText = `state: ${state.counter ?? 'loading...'}`;
-    const isDarkMode = state.theme?.isDark ?? false;
+
+    // Match Tauri example format for display items
+    const counterText = `Counter: ${state.counter ?? 0}`;
+    const themeText = `Theme: ${state.theme?.isDark ? 'Dark' : 'Light'}`;
+
     const contextMenu = Menu.buildFromTemplate([
+      // Display items (non-clickable)
       {
-        label: 'decrement',
-        type: 'normal',
-        click: () => {
-          dispatch('COUNTER:DECREMENT');
-          showWindow();
-        },
+        label: counterText,
+        enabled: false,
       },
       {
-        label: stateText,
-        type: 'normal',
-        click: () => showWindow(),
+        label: themeText,
+        enabled: false,
       },
+      { type: 'separator' },
+
+      // Action items
       {
-        label: 'increment',
-        type: 'normal',
+        label: 'Increment',
         click: () => {
           dispatch('COUNTER:INCREMENT');
           showWindow();
         },
       },
       {
-        label: 'double (thunk)',
-        type: 'normal',
+        label: 'Decrement',
         click: () => {
-          dispatch((getState, dispatch) => {
-            const currentValue = getState().counter || 0;
-            console.log(`[Tray] Thunk: Doubling counter from ${currentValue} to ${currentValue * 2}`);
-            dispatch('COUNTER:SET', currentValue * 2);
-          });
+          dispatch('COUNTER:DECREMENT');
           showWindow();
         },
       },
       {
-        label: 'double (action object)',
-        type: 'normal',
+        label: 'Reset Counter',
         click: () => {
-          const currentValue = state.counter || 0;
-          console.log(`[Tray] Action Object: Doubling counter from ${currentValue} to ${currentValue * 2}`);
-          dispatch({ type: 'COUNTER:SET', payload: currentValue * 2 });
+          dispatch('COUNTER:RESET');
           showWindow();
         },
       },
-      { type: 'separator' },
       {
-        label: `Switch theme to ${isDarkMode ? 'Light' : 'Dark'}`,
-        type: 'normal',
+        label: 'Toggle Theme',
         click: () => {
-          console.log(
-            `[Tray] Toggling theme from ${isDarkMode ? 'Dark' : 'Light'} to ${isDarkMode ? 'Light' : 'Dark'}`,
-          );
           dispatch('THEME:TOGGLE');
           showWindow();
         },
       },
       { type: 'separator' },
+
+      // Window and app control
       {
-        label: 'quit',
+        label: 'Show Window',
+        click: () => showWindow(),
+      },
+      {
+        label: 'Quit',
         click: () => {
           app.quit();
         },
@@ -134,7 +128,10 @@ export class BaseSystemTray {
     ]);
 
     this.electronTray.setContextMenu(contextMenu);
-    this.electronTray.setToolTip(stateText);
+    this.electronTray.setToolTip('Zubridge Electron Example');
+
+    // Add click handler to show window on left click
+    this.electronTray.on('click', showWindow);
   };
 
   public init(store: StoreApi<State>, window: BrowserWindow) {

--- a/apps/electron-example/src/main/window.ts
+++ b/apps/electron-example/src/main/window.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import process from 'node:process';
 import { BrowserWindow, BrowserView, WebContentsView, shell } from 'electron';
 import { isDev } from '@zubridge/electron';
 import { getModeName } from '../utils/mode.js';
@@ -10,7 +11,9 @@ function debugWindow(message: string) {
   console.log(`[WINDOW ${timestamp}] ${message}`);
 }
 
-debugWindow('Loading window module');
+// Check if running in test mode
+const isTestMode = process.env.TEST === 'true';
+debugWindow(`Test mode: ${isTestMode}`);
 
 // Window reference variables
 let mainWindow: BrowserWindow | undefined = undefined;
@@ -226,7 +229,13 @@ export function initDirectWebContentsWindow(): BrowserWindow {
 }
 
 // Function to initialize a third window with BrowserView
-export function initBrowserViewWindow(): { window: BrowserWindow; browserView: BrowserView } {
+export function initBrowserViewWindow(): { window: BrowserWindow | null; browserView: BrowserView | null } {
+  // Skip creation in test mode
+  if (isTestMode) {
+    debugWindow('Skipping BrowserView window creation in test mode');
+    return { window: null, browserView: null };
+  }
+
   debugWindow('Initializing BrowserView window');
   if (browserViewWindow && browserView && !browserViewWindow.isDestroyed()) {
     debugWindow('Reusing existing BrowserView window');
@@ -425,7 +434,13 @@ export function initBrowserViewWindow(): { window: BrowserWindow; browserView: B
 }
 
 // Function to initialize a fourth window with WebContentsView
-export function initWebContentsViewWindow(): { window: BrowserWindow; webContentsView: WebContentsView } {
+export function initWebContentsViewWindow(): { window: BrowserWindow | null; webContentsView: WebContentsView | null } {
+  // Skip creation in test mode
+  if (isTestMode) {
+    debugWindow('Skipping WebContentsView window creation in test mode');
+    return { window: null, webContentsView: null };
+  }
+
   debugWindow('Initializing WebContentsView window');
   if (webContentsViewWindow && webContentsView && !webContentsViewWindow.isDestroyed()) {
     debugWindow('Reusing existing WebContentsView window');

--- a/apps/electron-example/src/main/window.ts
+++ b/apps/electron-example/src/main/window.ts
@@ -1,0 +1,690 @@
+import path from 'node:path';
+import { BrowserWindow, BrowserView, WebContentsView, shell } from 'electron';
+import { isDev } from '@zubridge/electron';
+import { getModeName } from '../utils/mode.js';
+import { getPreloadPath } from '../utils/path.js';
+
+// Debug logger with timestamp
+function debugWindow(message: string) {
+  const timestamp = new Date().toISOString();
+  console.log(`[WINDOW ${timestamp}] ${message}`);
+}
+
+debugWindow('Loading window module');
+
+// Window reference variables
+let mainWindow: BrowserWindow | undefined = undefined;
+let directWebContentsWindow: BrowserWindow | undefined = undefined;
+let browserViewWindow: BrowserWindow | undefined = undefined;
+let browserView: BrowserView | undefined = undefined;
+let webContentsViewWindow: BrowserWindow | undefined = undefined;
+let webContentsView: WebContentsView | undefined = undefined;
+
+// Track runtime windows that need cleanup
+const runtimeWindows: BrowserWindow[] = [];
+
+// Configuration
+const modeName = getModeName();
+const preloadPath = getPreloadPath(path.join(__dirname));
+
+// Initialize isDev status
+let isDevEnv = false;
+isDev().then((result) => {
+  isDevEnv = result;
+  debugWindow(`Development mode set to: ${isDevEnv}`);
+});
+
+// Window sizes and positions for grid layout
+const windowWidth = 800;
+const windowHeight = 600;
+const windowSpacing = 20;
+
+const shouldQuit = (isAppQuitting: boolean) => {
+  return (
+    isAppQuitting ||
+    (directWebContentsWindow && !directWebContentsWindow.isDestroyed()) ||
+    (browserViewWindow && !browserViewWindow.isDestroyed()) ||
+    (webContentsViewWindow && !webContentsViewWindow.isDestroyed())
+  );
+};
+
+// Monitor window DOM content loaded
+function setupDomReadyLogging(window: BrowserWindow | BrowserView | WebContentsView, windowName: string) {
+  window.webContents.on('dom-ready', () => {
+    debugWindow(`${windowName} DOM ready`);
+  });
+
+  window.webContents.on('did-finish-load', () => {
+    debugWindow(`${windowName} finished loading`);
+  });
+
+  window.webContents.on('did-fail-load', (_event, errorCode, errorDescription) => {
+    debugWindow(`${windowName} failed to load: ${errorDescription} (${errorCode})`);
+  });
+}
+
+// Setup developer tools keyboard shortcuts
+function setupDevToolsShortcuts(window: BrowserWindow, windowName: string) {
+  // Register Cmd+Opt+I (Mac) / Ctrl+Shift+I (Windows/Linux) to toggle DevTools
+  window.webContents.on('before-input-event', (event, input) => {
+    const isMac = process.platform === 'darwin';
+    // For Mac: Cmd+Opt+I, For Windows/Linux: Ctrl+Shift+I
+    const devToolsShortcut = isMac
+      ? input.meta && input.alt && input.key === 'i'
+      : input.control && input.shift && input.key === 'i';
+
+    if (devToolsShortcut) {
+      debugWindow(`DevTools shortcut pressed in ${windowName}`);
+      if (window.webContents.isDevToolsOpened()) {
+        window.webContents.closeDevTools();
+        debugWindow(`DevTools closed for ${windowName}`);
+      } else {
+        window.webContents.openDevTools({ mode: 'detach' });
+        debugWindow(`DevTools opened for ${windowName}`);
+      }
+      event.preventDefault();
+    }
+  });
+}
+
+// Function to initialize the main window
+export function initMainWindow(isAppQuitting: boolean): BrowserWindow {
+  debugWindow('Initializing main window');
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    debugWindow('Reusing existing main window');
+    mainWindow.show();
+    return mainWindow;
+  }
+
+  mainWindow = new BrowserWindow({
+    width: windowWidth,
+    height: windowHeight,
+    x: 0,
+    y: 0,
+    title: `Zubridge Electron Example (${modeName}) - Main Window`,
+    webPreferences: {
+      preload: preloadPath,
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: false,
+    },
+  });
+
+  debugWindow(`Main window created with ID: ${mainWindow.id}, using preload: ${preloadPath}`);
+  mainWindow.setTitle(`Zubridge Electron Example (${modeName}) - Main Window`);
+
+  if (isDevEnv) {
+    debugWindow('Loading main window from dev server');
+    mainWindow.loadURL('http://localhost:5173/');
+  } else {
+    const htmlPath = path.join(__dirname, '..', 'renderer', 'index.html');
+    debugWindow(`Loading main window from file: ${htmlPath}`);
+    mainWindow.loadFile(htmlPath);
+  }
+
+  setupDomReadyLogging(mainWindow, 'Main window');
+  setupDevToolsShortcuts(mainWindow, 'Main window');
+
+  // Inject title update code
+  mainWindow.webContents.once('did-finish-load', () => {
+    debugWindow('Injecting title update code into main window');
+    mainWindow?.webContents
+      .executeJavaScript(
+        `
+        document.title = 'Zubridge Electron Example (${modeName}) - Main Window';
+        console.log('Main window title updated to:', document.title);
+      `,
+      )
+      .catch((err) => debugWindow(`Failed to inject title code: ${err}`));
+  });
+
+  mainWindow.on('ready-to-show', () => {
+    debugWindow('Main window ready to show');
+    mainWindow?.show();
+  });
+
+  mainWindow.on('close', (event) => {
+    debugWindow('Main window close event');
+    if (shouldQuit(isAppQuitting)) {
+      debugWindow('Allowing main window to close');
+      mainWindow = undefined; // Allow GC
+      return; // Allow closing if quitting or other primary window exists
+    }
+    debugWindow('Preventing main window close, hiding instead');
+    event.preventDefault();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.hide();
+    }
+  });
+
+  return mainWindow;
+}
+
+// Function to initialize the secondary window (registering webContents)
+export function initDirectWebContentsWindow(): BrowserWindow {
+  debugWindow('Initializing direct WebContents window');
+  if (directWebContentsWindow && !directWebContentsWindow.isDestroyed()) {
+    debugWindow('Reusing existing direct WebContents window');
+    directWebContentsWindow.show();
+    return directWebContentsWindow;
+  }
+
+  directWebContentsWindow = new BrowserWindow({
+    width: windowWidth,
+    height: windowHeight,
+    x: windowWidth + windowSpacing,
+    y: 0,
+    title: `Zubridge Electron Example (${modeName}) - Direct WebContents Window`,
+    webPreferences: {
+      preload: preloadPath,
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: false,
+    },
+  });
+
+  debugWindow(`Direct WebContents window created with ID: ${directWebContentsWindow.id}`);
+  directWebContentsWindow.setTitle(`Zubridge Electron Example (${modeName}) - Direct WebContents Window`);
+
+  if (isDevEnv) {
+    debugWindow('Loading direct WebContents window from dev server');
+    directWebContentsWindow.loadURL('http://localhost:5173/');
+  } else {
+    const htmlPath = path.join(__dirname, '..', 'renderer', 'index.html');
+    debugWindow(`Loading direct WebContents window from file: ${htmlPath}`);
+    directWebContentsWindow.loadFile(htmlPath);
+  }
+
+  setupDomReadyLogging(directWebContentsWindow, 'Direct WebContents window');
+  setupDevToolsShortcuts(directWebContentsWindow, 'Direct WebContents window');
+
+  // In renderer the WebContents instance is wrapped directly, so add a debug property
+  directWebContentsWindow.webContents.once('did-finish-load', () => {
+    debugWindow('Injecting debug code into direct WebContents window');
+    directWebContentsWindow?.webContents
+      .executeJavaScript(
+        `
+        document.title = 'Zubridge Electron Example (${modeName}) - Direct WebContents Window';
+        console.log('Direct WebContents window loaded and executing JavaScript');
+      `,
+      )
+      .catch((err) => debugWindow(`Failed to inject debug code: ${err}`));
+  });
+
+  directWebContentsWindow.on('ready-to-show', () => {
+    debugWindow('Direct WebContents window ready to show');
+    directWebContentsWindow?.show();
+  });
+
+  // Allow secondary window to close normally, but nullify reference
+  directWebContentsWindow.on('close', () => {
+    debugWindow('Direct WebContents window closing');
+    directWebContentsWindow = undefined;
+  });
+
+  return directWebContentsWindow;
+}
+
+// Function to initialize a third window with BrowserView
+export function initBrowserViewWindow(): { window: BrowserWindow; browserView: BrowserView } {
+  debugWindow('Initializing BrowserView window');
+  if (browserViewWindow && browserView && !browserViewWindow.isDestroyed()) {
+    debugWindow('Reusing existing BrowserView window');
+    browserViewWindow.show();
+    return { window: browserViewWindow, browserView };
+  }
+
+  browserViewWindow = new BrowserWindow({
+    width: windowWidth,
+    height: windowHeight,
+    x: 0,
+    y: windowHeight + windowSpacing,
+    title: `Zubridge Electron Example (${modeName}) - BrowserView Window`,
+  });
+
+  debugWindow(`BrowserView window created with ID: ${browserViewWindow.id}`);
+
+  // Create a BrowserView to host our content
+  browserView = new BrowserView({
+    webPreferences: {
+      preload: preloadPath,
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: false,
+      devTools: true,
+    },
+  });
+
+  debugWindow('BrowserView created, attaching to window');
+
+  // Add the browser view to the window
+  try {
+    browserViewWindow.setBrowserView(browserView);
+    debugWindow('setBrowserView successful');
+
+    // Size the BrowserView to fill the window
+    const bounds = browserViewWindow.getBounds();
+    debugWindow(`Setting BrowserView bounds to: ${JSON.stringify(bounds)}`);
+
+    // Use setAutoResize to handle window resizing automatically
+    try {
+      browserView.setAutoResize({ width: true, height: true });
+      debugWindow('Auto-resize set for BrowserView');
+    } catch (e) {
+      debugWindow(`Error setting auto-resize: ${e}`);
+    }
+
+    browserView.setBounds({
+      x: 0,
+      y: 0,
+      width: bounds.width,
+      height: bounds.height,
+    });
+  } catch (e) {
+    debugWindow(`Error attaching BrowserView: ${e}`);
+    // Fallback to direct content loading in the window if setBrowserView fails
+    debugWindow('Fallback to loading content directly in the window');
+    if (isDevEnv) {
+      browserViewWindow.loadURL('http://localhost:5173/');
+    } else {
+      browserViewWindow.loadFile(path.join(__dirname, '..', 'renderer', 'index.html'), {
+        hash: 'browserView',
+      });
+    }
+    // Return early with a null browserView to signal that it wasn't attached
+    return { window: browserViewWindow, browserView: null as any };
+  }
+
+  setupDomReadyLogging(browserView as any, 'BrowserView');
+
+  // Load the secondary window content
+  if (isDevEnv) {
+    debugWindow('Loading BrowserView from dev server');
+    if (browserView) {
+      browserView.webContents.loadURL('http://localhost:5173/');
+
+      // Only open DevTools for the view's webContents, not the window's
+      setTimeout(() => {
+        debugWindow('Opening DevTools for BrowserView');
+        if (browserView) {
+          browserView.webContents.openDevTools({ mode: 'detach' });
+          debugWindow('DevTools opened for BrowserView webContents');
+        }
+      }, 1000);
+    }
+  } else {
+    debugWindow('Loading BrowserView from file with hash "secondary"');
+    if (browserView) {
+      browserView.webContents.loadFile(path.join(__dirname, '..', 'renderer', 'index.html'), { hash: 'browserView' });
+    }
+  }
+
+  browserView.webContents.setWindowOpenHandler(({ url }) => {
+    debugWindow(`BrowserView handled external URL: ${url}`);
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  // Set up resize handler
+  browserViewWindow.on('resize', () => {
+    try {
+      const newBounds = browserViewWindow?.getBounds();
+      if (!browserViewWindow || !newBounds) {
+        debugWindow('Cannot resize BrowserView: browserViewWindow is undefined');
+        return;
+      }
+
+      debugWindow(
+        `Resizing BrowserView to: ${JSON.stringify({
+          width: newBounds.width,
+          height: newBounds.height,
+        })}`,
+      );
+
+      browserView?.setBounds({
+        x: 0,
+        y: 0,
+        width: newBounds.width,
+        height: newBounds.height,
+      });
+    } catch (e) {
+      debugWindow(`Error during BrowserView resize: ${e}`);
+    }
+  });
+
+  browserViewWindow.on('closed', () => {
+    debugWindow('BrowserView window closed');
+  });
+
+  // Inject debug code
+  browserView.webContents.once('did-finish-load', () => {
+    debugWindow('Injecting debug code into BrowserView');
+    browserView?.webContents
+      .executeJavaScript(
+        `
+        document.title = 'Zubridge Electron Example (${modeName}) - BrowserView Window';
+        console.log('BrowserView loaded and executing JavaScript');
+
+        // Check if Zubridge is available
+        if (window.zubridge) {
+          console.log('Zubridge found in BrowserView');
+        } else {
+          console.error('Zubridge NOT found in BrowserView');
+        }
+      `,
+      )
+      .catch((err) => debugWindow(`Failed to inject debug code: ${err}`));
+  });
+
+  // Register keyboard shortcut on window's webContents
+  if (browserViewWindow) {
+    browserViewWindow.webContents.on('before-input-event', (event, input) => {
+      const isMac = process.platform === 'darwin';
+      const devToolsShortcut = isMac
+        ? input.meta && input.alt && input.key === 'i'
+        : input.control && input.shift && input.key === 'i';
+
+      if (devToolsShortcut) {
+        debugWindow('DevTools shortcut pressed in BrowserView window');
+        event.preventDefault();
+        // Forward this shortcut to the browserView webContents instead
+        if (browserView && !browserView.webContents.isDevToolsOpened()) {
+          browserView.webContents.openDevTools({ mode: 'detach' });
+          debugWindow('Opened DevTools for BrowserView webContents');
+        } else if (browserView) {
+          browserView.webContents.closeDevTools();
+          debugWindow('Closed DevTools for BrowserView webContents');
+        }
+      }
+    });
+  }
+
+  // Also register on view's webContents as a fallback
+  if (browserView) {
+    browserView.webContents.on('before-input-event', (event, input) => {
+      const isMac = process.platform === 'darwin';
+      const devToolsShortcut = isMac
+        ? input.meta && input.alt && input.key === 'i'
+        : input.control && input.shift && input.key === 'i';
+
+      if (devToolsShortcut) {
+        debugWindow('DevTools shortcut pressed in BrowserView');
+        if (browserView && browserView.webContents.isDevToolsOpened()) {
+          browserView.webContents.closeDevTools();
+          debugWindow('Closed DevTools for BrowserView');
+        } else if (browserView) {
+          browserView.webContents.openDevTools({ mode: 'detach' });
+          debugWindow('Opened DevTools for BrowserView');
+        }
+        event.preventDefault();
+      }
+    });
+  }
+
+  return { window: browserViewWindow, browserView };
+}
+
+// Function to initialize a fourth window with WebContentsView
+export function initWebContentsViewWindow(): { window: BrowserWindow; webContentsView: WebContentsView } {
+  debugWindow('Initializing WebContentsView window');
+  if (webContentsViewWindow && webContentsView && !webContentsViewWindow.isDestroyed()) {
+    debugWindow('Reusing existing WebContentsView window');
+    webContentsViewWindow.show();
+    return { window: webContentsViewWindow, webContentsView };
+  }
+
+  webContentsViewWindow = new BrowserWindow({
+    width: windowWidth,
+    height: windowHeight,
+    x: windowWidth + windowSpacing,
+    y: windowHeight + windowSpacing,
+    title: `Zubridge Electron Example (${modeName}) - WebContentsView Window`,
+  });
+
+  debugWindow(`WebContentsView window created with ID: ${webContentsViewWindow.id}`);
+
+  // Create a WebContentsView to host our content
+  webContentsView = new WebContentsView({
+    webPreferences: {
+      preload: preloadPath,
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: false,
+      devTools: true,
+    },
+  });
+
+  debugWindow('WebContentsView created, attaching to window');
+
+  try {
+    // Add the WebContentsView to the window
+    webContentsViewWindow.setContentView(webContentsView);
+    debugWindow('setContentView successful');
+  } catch (e) {
+    debugWindow(`Error setting content view: ${e}`);
+    // WebContentsView can only be set with setContentView, not setBrowserView
+    // Fallback to direct content loading in the window if setContentView fails
+    debugWindow('Fallback to loading content directly in the window');
+    if (isDevEnv) {
+      webContentsViewWindow.loadURL('http://localhost:5173/');
+    } else {
+      webContentsViewWindow.loadFile(path.join(__dirname, '..', 'renderer', 'index.html'), {
+        hash: 'secondary',
+      });
+    }
+    // Return early with a null webContentsView to signal that it wasn't attached
+    return { window: webContentsViewWindow, webContentsView: null as any };
+  }
+
+  // Size the WebContentsView to fill the window
+  const bounds = webContentsViewWindow.getBounds();
+  debugWindow(`Setting WebContentsView bounds to: ${JSON.stringify(bounds)}`);
+
+  webContentsView.setBounds({
+    x: 0,
+    y: 0,
+    width: bounds.width,
+    height: bounds.height,
+  });
+
+  setupDomReadyLogging(webContentsView, 'WebContentsView');
+
+  // Load the content
+  if (isDevEnv) {
+    debugWindow('Loading WebContentsView from dev server');
+    try {
+      if (webContentsView) {
+        webContentsView.webContents.loadURL('http://localhost:5173/');
+
+        // Only open DevTools for the view's webContents, not the window's
+        setTimeout(() => {
+          debugWindow('Opening DevTools for WebContentsView');
+          if (webContentsView) {
+            webContentsView.webContents.openDevTools();
+            debugWindow('DevTools opened for WebContentsView webContents');
+          }
+        }, 1000);
+      }
+    } catch (e) {
+      debugWindow(`Error loading URL in WebContentsView: ${e}`);
+      // Try alternatives if the previous method fails
+      try {
+        if (webContentsViewWindow) {
+          debugWindow('Trying loadURL on window instead');
+          webContentsViewWindow.loadURL('http://localhost:5173/');
+        }
+      } catch (e2) {
+        debugWindow(`Alternative loading also failed: ${e2}`);
+      }
+    }
+  } else {
+    try {
+      if (webContentsView) {
+        debugWindow('Loading WebContentsView from file with hash "secondary"');
+        webContentsView.webContents.loadFile(path.join(__dirname, '..', 'renderer', 'index.html'), {
+          hash: 'secondary',
+        });
+      }
+    } catch (e) {
+      debugWindow(`Error loading file in WebContentsView: ${e}`);
+    }
+  }
+
+  // Inject debug code
+  webContentsView.webContents.once('did-finish-load', () => {
+    debugWindow('Injecting debug code into WebContentsView');
+    webContentsView?.webContents
+      .executeJavaScript(
+        `
+      console.log('WebContentsView loaded and executing JavaScript');
+      document.title = document.title + ' (WebContentsView)';
+
+      // Check if Zubridge is available
+      if (window.zubridge) {
+        console.log('Zubridge found in WebContentsView');
+      } else {
+        console.error('Zubridge NOT found in WebContentsView');
+      }
+    `,
+      )
+      .catch((err) => debugWindow(`Failed to inject debug code: ${err}`));
+  });
+
+  webContentsView.webContents.setWindowOpenHandler(({ url }) => {
+    debugWindow(`WebContentsView handled external URL: ${url}`);
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  // Set up resize handler
+  webContentsViewWindow.on('resize', () => {
+    try {
+      const newBounds = webContentsViewWindow?.getBounds();
+      if (!webContentsViewWindow || !newBounds) {
+        debugWindow('Cannot resize WebContentsView: webContentsViewWindow is undefined');
+        return;
+      }
+
+      debugWindow(
+        `Resizing WebContentsView to: ${JSON.stringify({
+          width: newBounds.width,
+          height: newBounds.height,
+        })}`,
+      );
+
+      webContentsView?.setBounds({
+        x: 0,
+        y: 0,
+        width: newBounds.width,
+        height: newBounds.height,
+      });
+    } catch (e) {
+      debugWindow(`Error during WebContentsView resize: ${e}`);
+    }
+  });
+
+  webContentsViewWindow.on('closed', () => {
+    debugWindow('WebContentsView window closed');
+  });
+
+  return { window: webContentsViewWindow, webContentsView };
+}
+
+// Function to create a new runtime window
+export function createRuntimeWindow(): BrowserWindow {
+  debugWindow('Creating runtime window');
+
+  const runtimeWindow = new BrowserWindow({
+    width: 450,
+    height: 390,
+    title: `Zubridge Electron Example (${modeName}) - Runtime Window`,
+    webPreferences: {
+      preload: preloadPath,
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: false,
+    },
+  });
+
+  debugWindow(`Runtime window created with ID: ${runtimeWindow.id}`);
+
+  // Track this window
+  runtimeWindows.push(runtimeWindow);
+  debugWindow(`Runtime window ${runtimeWindow.id} added to tracking. Total: ${runtimeWindows.length}`);
+
+  if (isDevEnv) {
+    debugWindow('Loading runtime window from dev server');
+    runtimeWindow.loadURL('http://localhost:5173/');
+  } else {
+    const htmlPath = path.join(__dirname, '..', 'renderer', 'index.html');
+    debugWindow(`Loading runtime window from file: ${htmlPath}`);
+    runtimeWindow.loadFile(htmlPath);
+  }
+
+  setupDomReadyLogging(runtimeWindow, 'Runtime window');
+
+  runtimeWindow.on('ready-to-show', () => {
+    debugWindow(`Runtime window ${runtimeWindow.id} ready to show`);
+    runtimeWindow.show();
+  });
+
+  // Important: Clean up from runtimeWindows array when closed
+  runtimeWindow.once('closed', () => {
+    debugWindow(`Runtime window ${runtimeWindow.id} closed event`);
+    const index = runtimeWindows.findIndex((w) => w.id === runtimeWindow.id);
+    if (index !== -1) {
+      runtimeWindows.splice(index, 1);
+      debugWindow(`Runtime window ${runtimeWindow.id} removed from tracking. Remaining: ${runtimeWindows.length}`);
+    }
+  });
+
+  return runtimeWindow;
+}
+
+// Clean up all windows
+export function cleanupWindows(): void {
+  debugWindow('Starting window cleanup');
+
+  // Close runtime windows
+  debugWindow(`Cleaning up ${runtimeWindows.length} runtime windows`);
+  runtimeWindows.forEach((window) => {
+    if (window && !window.isDestroyed()) {
+      debugWindow(`Closing runtime window ${window.id}`);
+      window.removeAllListeners('closed'); // Prevent listener leaks
+      window.close();
+    }
+  });
+  runtimeWindows.length = 0;
+
+  // Explicitly destroy core windows if they weren't closed
+  debugWindow('Cleaning up main windows');
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    debugWindow('Destroying main window');
+    mainWindow.destroy();
+  }
+  if (directWebContentsWindow && !directWebContentsWindow.isDestroyed()) {
+    debugWindow('Destroying direct WebContents window');
+    directWebContentsWindow.destroy();
+  }
+  if (browserViewWindow && !browserViewWindow.isDestroyed()) {
+    debugWindow('Destroying BrowserView window');
+    browserViewWindow.destroy();
+  }
+  if (webContentsViewWindow && !webContentsViewWindow.isDestroyed()) {
+    debugWindow('Destroying WebContentsView window');
+    webContentsViewWindow.destroy();
+  }
+
+  debugWindow('Window cleanup complete');
+}
+
+// Get window references
+export function getWindowRefs() {
+  return {
+    mainWindow,
+    directWebContentsWindow,
+    browserViewWindow,
+    webContentsViewWindow,
+    runtimeWindows,
+  };
+}

--- a/apps/electron-example/src/modes/basic/features/counter/index.ts
+++ b/apps/electron-example/src/modes/basic/features/counter/index.ts
@@ -39,5 +39,14 @@ export const attachCounterHandlers = <S extends BaseState>(store: StoreApi<S>) =
         counter: value,
       }));
     },
+
+    // Implement a reset counter handler
+    'COUNTER:RESET': () => {
+      console.log('[Basic] Resetting counter to 0');
+      setState((state) => ({
+        ...state,
+        counter: 0,
+      }));
+    },
   }));
 };

--- a/apps/electron-example/src/modes/basic/features/index.ts
+++ b/apps/electron-example/src/modes/basic/features/index.ts
@@ -14,6 +14,8 @@ export interface State extends BaseState {
   // Action handlers
   'COUNTER:INCREMENT': () => void;
   'COUNTER:DECREMENT': () => void;
+  'COUNTER:SET': (value: number) => void;
+  'COUNTER:RESET': () => void;
   'WINDOW:CREATE': () => void;
   'WINDOW:CLOSE': (payload?: { windowId?: number }) => void;
 }

--- a/apps/electron-example/src/modes/basic/main.ts
+++ b/apps/electron-example/src/modes/basic/main.ts
@@ -1,7 +1,8 @@
 import { createZustandBridge } from '@zubridge/electron/main';
-import type { BrowserWindow } from 'electron';
+import type { WebContents } from 'electron';
 import type { StoreApi } from 'zustand';
 import type { ZustandBridge } from '@zubridge/electron/main';
+import type { WebContentsWrapper } from '@zubridge/types';
 
 import { attachCounterHandlers } from './features/counter/index.js';
 import { attachThemeHandlers } from './features/theme/index.js';
@@ -13,7 +14,7 @@ import type { BaseState } from '../../types/index.js';
  */
 export const createBasicBridge = <S extends BaseState, Store extends StoreApi<S>>(
   store: Store,
-  windows: BrowserWindow[],
+  windows: (WebContentsWrapper | WebContents)[],
 ): ZustandBridge => {
   console.log('[Basic Mode] Creating bridge with store-based handlers');
 

--- a/apps/electron-example/src/modes/custom/features/counter/index.ts
+++ b/apps/electron-example/src/modes/custom/features/counter/index.ts
@@ -31,5 +31,15 @@ export const setValue = (value: number): Partial<AnyState> => {
   };
 };
 
+/**
+ * Counter reset action handler for custom mode
+ */
+export const reset = (): Partial<AnyState> => {
+  console.log('[Custom Counter] Resetting counter to 0');
+  return {
+    counter: 0,
+  };
+};
+
 // Export default initial state
 export const initialState = 0;

--- a/apps/electron-example/src/modes/custom/features/index.ts
+++ b/apps/electron-example/src/modes/custom/features/index.ts
@@ -17,6 +17,7 @@ export const handlers = {
   'COUNTER:INCREMENT': (state: AnyState) => counter.increment(state),
   'COUNTER:DECREMENT': (state: AnyState) => counter.decrement(state),
   'COUNTER:SET': (payload: number) => counter.setValue(payload),
+  'COUNTER:RESET': () => counter.reset(),
   'THEME:TOGGLE': (state: AnyState) => theme.toggle(state),
   'THEME:SET': (payload: boolean) => theme.setValue(payload),
 };

--- a/apps/electron-example/src/modes/custom/main.ts
+++ b/apps/electron-example/src/modes/custom/main.ts
@@ -1,5 +1,6 @@
 import { createCoreBridge, createDispatch } from '@zubridge/electron/main';
-import type { BrowserWindow } from 'electron';
+import type { WebContentsWrapper } from '@zubridge/types';
+import type { WebContents } from 'electron';
 import type { ZustandBridge } from '@zubridge/electron/main';
 import type { StateManager } from '@zubridge/types';
 import { getCustomStore } from './store.js';
@@ -8,7 +9,7 @@ import { getCustomStore } from './store.js';
  * Creates a bridge using the custom store approach
  * This demonstrates how to use createCoreBridge with a custom state manager
  */
-export const createCustomBridge = (windows: BrowserWindow[] = []): ZustandBridge => {
+export const createCustomBridge = (windows: (WebContentsWrapper | WebContents)[] = []): ZustandBridge => {
   console.log('[Custom Mode] Creating bridge with custom state manager');
 
   // Get a CustomStore instance from our implementation

--- a/apps/electron-example/src/modes/handlers/features/counter/index.ts
+++ b/apps/electron-example/src/modes/handlers/features/counter/index.ts
@@ -40,3 +40,16 @@ export const setCounter =
       counter: value,
     }));
   };
+
+/**
+ * Creates a handler function for resetting the counter to zero
+ */
+export const resetCounter =
+  <S extends State>(store: StoreApi<S>) =>
+  () => {
+    console.log('[Handler] Resetting counter to 0');
+    store.setState((state) => ({
+      ...state,
+      counter: 0,
+    }));
+  };

--- a/apps/electron-example/src/modes/handlers/features/index.ts
+++ b/apps/electron-example/src/modes/handlers/features/index.ts
@@ -15,6 +15,7 @@ export interface CounterHandlers {
   'COUNTER:INCREMENT': () => void;
   'COUNTER:DECREMENT': () => void;
   'COUNTER:SET': (value: number) => void;
+  'COUNTER:RESET': () => void;
 }
 
 /**

--- a/apps/electron-example/src/modes/handlers/index.ts
+++ b/apps/electron-example/src/modes/handlers/index.ts
@@ -1,0 +1,1 @@
+/* handlers mode index - combine all features */

--- a/apps/electron-example/src/modes/handlers/main.ts
+++ b/apps/electron-example/src/modes/handlers/main.ts
@@ -1,10 +1,11 @@
 import { createZustandBridge } from '@zubridge/electron/main';
-import type { BrowserWindow } from 'electron';
+import type { WebContentsWrapper } from '@zubridge/types';
+import type { WebContents } from 'electron';
 import type { StoreApi } from 'zustand';
 import type { ZustandBridge } from '@zubridge/electron/main';
 
 // Import counter handlers
-import { incrementCounter, decrementCounter, setCounter } from './features/counter/index.js';
+import { incrementCounter, decrementCounter, setCounter, resetCounter } from './features/counter/index.js';
 // Import theme handlers
 import { toggleTheme, setTheme } from './features/theme/index.js';
 // Import the state type
@@ -19,6 +20,7 @@ export const createHandlers = <S extends BaseState>(store: StoreApi<S>): ActionH
     'COUNTER:INCREMENT': incrementCounter(store),
     'COUNTER:DECREMENT': decrementCounter(store),
     'COUNTER:SET': setCounter(store),
+    'COUNTER:RESET': resetCounter(store),
     'THEME:TOGGLE': toggleTheme(store),
     'THEME:SET': setTheme(store),
   };
@@ -30,7 +32,7 @@ export const createHandlers = <S extends BaseState>(store: StoreApi<S>): ActionH
  */
 export const createHandlersBridge = <S extends BaseState, Store extends StoreApi<S>>(
   store: Store,
-  windows: BrowserWindow[],
+  windows: (WebContentsWrapper | WebContents)[],
 ): ZustandBridge => {
   console.log('[Handlers Mode] Creating bridge with separate handlers');
 

--- a/apps/electron-example/src/modes/reducers/features/counter/index.ts
+++ b/apps/electron-example/src/modes/reducers/features/counter/index.ts
@@ -4,6 +4,7 @@ import type { Action } from '@zubridge/types';
 export type CounterAction =
   | { type: 'COUNTER:INCREMENT' }
   | { type: 'COUNTER:DECREMENT' }
+  | { type: 'COUNTER:RESET' }
   | { type: 'COUNTER:SET'; payload: number };
 
 /**
@@ -19,6 +20,9 @@ export const reducer: Reducer<number> = (counter = 0, action: Action) => {
     case 'COUNTER:DECREMENT':
       console.log('[Reducer] Decrementing counter');
       return counter - 1;
+    case 'COUNTER:RESET':
+      console.log('[Reducer] Resetting counter to 0');
+      return 0;
     case 'COUNTER:SET':
       console.log(`[Reducer] Setting counter to ${action.payload}`);
       return action.payload as number;

--- a/apps/electron-example/src/modes/reducers/main.ts
+++ b/apps/electron-example/src/modes/reducers/main.ts
@@ -1,5 +1,6 @@
 import { createZustandBridge } from '@zubridge/electron/main';
-import type { BrowserWindow } from 'electron';
+import type { WebContentsWrapper } from '@zubridge/types';
+import type { WebContents } from 'electron';
 import type { StoreApi } from 'zustand';
 import type { RootReducer } from '@zubridge/types';
 import type { ZustandBridge } from '@zubridge/electron/main';
@@ -14,7 +15,7 @@ import type { BaseState } from '../../types/index.js';
  */
 export const createReducersBridge = <S extends BaseState, Store extends StoreApi<S>>(
   store: Store,
-  windows: BrowserWindow[],
+  windows: (WebContentsWrapper | WebContents)[],
 ): ZustandBridge => {
   console.log('[Reducers Mode] Creating bridge with reducer');
 

--- a/apps/electron-example/src/modes/redux/features/counter/index.ts
+++ b/apps/electron-example/src/modes/redux/features/counter/index.ts
@@ -8,6 +8,7 @@ const initialState = 0;
 export const increment = createAction('COUNTER:INCREMENT');
 export const decrement = createAction('COUNTER:DECREMENT');
 export const setValue = createAction<number>('COUNTER:SET');
+export const reset = createAction('COUNTER:RESET');
 
 // Traditional reducer function that handles our specific action types directly
 export const counterReducer = (state = initialState, action: AnyAction) => {
@@ -21,6 +22,9 @@ export const counterReducer = (state = initialState, action: AnyAction) => {
     case 'COUNTER:SET':
       console.log(`[Redux Reducer] Setting counter to ${action.payload}`);
       return action.payload;
+    case 'COUNTER:RESET':
+      console.log('[Redux Reducer] Resetting counter to 0');
+      return 0;
     default:
       return state;
   }

--- a/apps/electron-example/src/modes/redux/main.ts
+++ b/apps/electron-example/src/modes/redux/main.ts
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { createCoreBridge, createDispatch } from '@zubridge/electron/main';
-import type { BrowserWindow } from 'electron';
+import type { WebContentsWrapper } from '@zubridge/types';
+import type { WebContents } from 'electron';
 import type { Dispatch, Store } from 'redux';
 import type { ZustandBridge } from '@zubridge/electron/main';
 import type { StateManager, Action } from '@zubridge/types';
@@ -29,7 +30,10 @@ export function createStore() {
  * Creates a bridge using the Redux approach
  * In this approach, we use Redux with Redux Toolkit to manage state
  */
-export const createReduxBridge = (store: Store<any> | null = null, windows: BrowserWindow[] = []): ZustandBridge => {
+export const createReduxBridge = (
+  store: Store<any> | null = null,
+  windows: (WebContentsWrapper | WebContents)[] = [],
+): ZustandBridge => {
   console.log('[Redux Mode] Creating bridge with Redux store');
 
   // Create a store if one wasn't provided

--- a/apps/electron-example/src/renderer/App.main.tsx
+++ b/apps/electron-example/src/renderer/App.main.tsx
@@ -8,7 +8,7 @@ import './styles/main-window.css';
 interface MainAppProps {
   windowId: number;
   modeName: string;
-  windowType?: 'main' | 'secondary'; // Add window type parameter
+  windowType?: 'main' | 'directWebContents' | 'browserView' | 'webContentsView' | 'runtime'; // Add window type parameter
 }
 
 interface CounterObject {
@@ -119,6 +119,11 @@ export function MainApp({ windowId, modeName, windowType = 'main' }: MainAppProp
     });
   };
 
+  const handleResetCounter = () => {
+    console.log('[App.main] Resetting counter');
+    dispatch('COUNTER:RESET');
+  };
+
   const handleToggleTheme = () => {
     console.log('[App.main] Toggling theme');
     dispatch('THEME:TOGGLE');
@@ -148,18 +153,17 @@ export function MainApp({ windowId, modeName, windowType = 'main' }: MainAppProp
     }
   };
 
-  // Determine window title based on type
-  const windowTitle = windowType === 'secondary' ? 'Secondary' : 'Main';
-
   // Format counter for display to ensure we always render a primitive (number or string)
   const displayCounter =
     typeof counter === 'object' && counter !== null && 'value' in counter ? (counter as CounterObject).value : counter;
+
+  const windowTypeDisplay = windowType.charAt(0).toUpperCase() + windowType.slice(1);
 
   return (
     <div className="app-container">
       {/* Fixed header to display window ID and type */}
       <div className="fixed-header">
-        {windowTitle} Window - {modeName} (ID: <span className="window-id">{windowId}</span>)
+        {windowTypeDisplay} Window - {modeName} (ID: <span className="window-id">{windowId}</span>)
       </div>
 
       <div className="content">
@@ -170,7 +174,10 @@ export function MainApp({ windowId, modeName, windowType = 'main' }: MainAppProp
             <button onClick={handleDecrement}>-</button>
             <button onClick={handleIncrement}>+</button>
             <button onClick={handleDoubleCounter}>Double (Thunk)</button>
-            <button onClick={handleDoubleWithObject}>Double (Action Object)</button>
+            <button onClick={handleDoubleWithObject}>Double (Object)</button>
+            <button onClick={handleResetCounter} className="reset-button">
+              Reset
+            </button>
           </div>
         </div>
 
@@ -187,8 +194,8 @@ export function MainApp({ windowId, modeName, windowType = 'main' }: MainAppProp
                 Quit App
               </button>
             )}
-            {/* Show close button on secondary window */}
-            {windowType === 'secondary' && (
+            {/* Show close button on non-main window */}
+            {windowType !== 'main' && (
               <button onClick={() => window.electronAPI?.closeCurrentWindow()} className="close-button">
                 Close Window
               </button>

--- a/apps/electron-example/src/renderer/App.runtime.tsx
+++ b/apps/electron-example/src/renderer/App.runtime.tsx
@@ -1,11 +1,9 @@
 // @ts-ignore: React is used for JSX
 import React from 'react';
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from '@zubridge/electron';
 import { useStore } from './hooks/useStore';
 import './styles/runtime-window.css';
-import type { State } from '../types/index.js';
-import type { AnyState } from '@zubridge/types';
 
 interface RuntimeAppProps {
   modeName: string;
@@ -52,6 +50,15 @@ export function RuntimeApp({ modeName, windowId }: RuntimeAppProps) {
       dispatch('COUNTER:DECREMENT');
     } catch (error) {
       console.error('Error dispatching decrement action:', error);
+    }
+  };
+
+  const resetCounter = () => {
+    try {
+      console.log(`[Runtime ${windowId}] Dispatching COUNTER:RESET action`);
+      dispatch('COUNTER:RESET');
+    } catch (error) {
+      console.error('Error dispatching reset action:', error);
     }
   };
 
@@ -165,8 +172,11 @@ export function RuntimeApp({ modeName, windowId }: RuntimeAppProps) {
           <div className="button-group">
             <button onClick={decrementCounter}>-</button>
             <button onClick={incrementCounter}>+</button>
-            <button onClick={doubleCounterThunk}>double (thunk)</button>
-            <button onClick={doubleCounterAction}>double (action object)</button>
+            <button onClick={doubleCounterThunk}>Double (Thunk)</button>
+            <button onClick={doubleCounterAction}>Double (Object)</button>
+            <button onClick={resetCounter} className="reset-button">
+              Reset
+            </button>
           </div>
         </div>
 

--- a/apps/electron-example/src/renderer/electron-api.ts
+++ b/apps/electron-example/src/renderer/electron-api.ts
@@ -1,0 +1,7 @@
+export interface ElectronAPI {
+  getWindowInfo: () => Promise<{ id: number }>;
+  getMode: () => Promise<{ name: string }>;
+  createRuntimeWindow: () => Promise<any>;
+  closeCurrentWindow: () => void;
+  quitApp: () => void;
+}

--- a/apps/electron-example/src/renderer/styles/main-window.css
+++ b/apps/electron-example/src/renderer/styles/main-window.css
@@ -445,3 +445,18 @@ body.dark-theme .window-id,
 body:not(.light-theme):not(.dark-theme) .window-id {
   color: white !important;
 }
+
+/* Reset button style */
+.reset-button {
+  background-color: #f5c211 !important; /* Yellow */
+  min-width: 140px !important;
+  grid-column: 1 / -1;
+}
+
+.reset-button:hover {
+  background-color: #e6b800 !important; /* Darker yellow on hover */
+}
+
+.reset-button:active {
+  background-color: #cc9900 !important; /* Even darker yellow when active */
+}

--- a/apps/electron-example/src/renderer/styles/runtime-window.css
+++ b/apps/electron-example/src/renderer/styles/runtime-window.css
@@ -41,6 +41,23 @@ body {
   min-width: 0;
 }
 
+/* Counter section button layout */
+.runtime-window .counter-section .button-group {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto auto;
+  gap: 10px;
+  width: 100%;
+  max-width: 260px;
+}
+
+/* Make double buttons and reset button take full width */
+.runtime-window .counter-section .button-group button:nth-child(3),
+.runtime-window .counter-section .button-group button:nth-child(4),
+.runtime-window .counter-section .button-group button:nth-child(5) {
+  grid-column: 1 / -1;
+}
+
 /* Consistent styling for close/quit buttons regardless of window type */
 .close-button,
 .window-button-group .close-button {

--- a/apps/electron-example/src/renderer/types.d.ts
+++ b/apps/electron-example/src/renderer/types.d.ts
@@ -1,4 +1,4 @@
-import type { ElectronAPI } from './types';
+import type { ElectronAPI } from './electron-api';
 
 declare global {
   interface Window {

--- a/e2e/test/interaction.spec.ts
+++ b/e2e/test/interaction.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from '@wdio/globals';
+import { expect, it, describe, before, beforeEach } from '@wdio/globals';
 import { browser } from 'wdio-electron-service';
 
 // Platform-specific timing configurations
@@ -34,7 +34,9 @@ console.log(`Using timing configuration for platform: ${PLATFORM}`);
 const windowHandles: string[] = [];
 
 // Names of core windows for easier reference in tests
-const CORE_WINDOW_NAMES = ['Main', 'DirectWebContents', 'BrowserView', 'WebContentsView'];
+// UPDATED: Reduced to only Main and DirectWebContents windows
+// TODO: Add BrowserView and WebContentsView windows when we have fixed the Webdriver connection issues
+const CORE_WINDOW_NAMES = ['Main', 'DirectWebContents'];
 const CORE_WINDOW_COUNT = CORE_WINDOW_NAMES.length;
 
 // Helper to refresh window handles
@@ -113,7 +115,7 @@ const switchToWindow = async (index: number) => {
   }
 };
 
-// Helper to close all windows except the core windows (main, directWebContents, browserView, webContentsView)
+// Helper to close all windows except the core windows
 const closeAllRemainingWindows = async () => {
   try {
     // Refresh window handles to get latest state
@@ -129,7 +131,7 @@ const closeAllRemainingWindows = async () => {
     // First try to close via Electron API directly for reliability
     await browser.electron.execute((electron, coreCount) => {
       const windows = electron.BrowserWindow.getAllWindows();
-      // Keep only the first four windows (core windows)
+      // Keep only the core windows
       for (let i = coreCount; i < windows.length; i++) {
         try {
           console.log(`Direct close of window index ${i} with ID ${windows[i].id}`);

--- a/e2e/test/interaction.spec.ts
+++ b/e2e/test/interaction.spec.ts
@@ -1,4 +1,5 @@
-import { expect, it, describe, before, beforeEach } from '@wdio/globals';
+import { expect } from '@wdio/globals';
+import { it, describe, before, beforeEach } from 'mocha';
 import { browser } from 'wdio-electron-service';
 
 // Platform-specific timing configurations

--- a/e2e/test/interaction.spec.ts
+++ b/e2e/test/interaction.spec.ts
@@ -399,7 +399,7 @@ describe('application loading', () => {
       expect(await initialCounter.getText()).toContain('2');
 
       // Click the double button
-      const doubleButton = await browser.$('button=Double (Action Object)');
+      const doubleButton = await browser.$('button=Double (Object)');
       await doubleButton.click();
       await browser.pause(CURRENT_TIMING.BUTTON_CLICK_PAUSE * 2);
 

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -69,7 +69,9 @@ const config = {
       'browserName': 'electron',
       'wdio:electronServiceOptions': {
         appBinaryPath: binaryPath,
-        appArgs: process.env.ELECTRON_APP_PATH ? [process.env.ELECTRON_APP_PATH, '--no-sandbox'] : ['--no-sandbox'],
+        appArgs: process.env.ELECTRON_APP_PATH
+          ? [process.env.ELECTRON_APP_PATH, '--no-sandbox', '--disable-gpu']
+          : ['--no-sandbox', '--disable-gpu'],
         appEnv: { ZUBRIDGE_MODE: mode },
         browserVersion: electronVersion,
         restoreMocks: true,

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -61,6 +61,9 @@ if (fs.existsSync(macAppPath)) {
   }
 }
 
+const baseArgs = ['--no-sandbox', '--disable-gpu'];
+const appArgs = process.env.ELECTRON_APP_PATH ? [process.env.ELECTRON_APP_PATH, ...baseArgs] : baseArgs;
+
 // Get the config that will be exported
 const config = {
   services: ['electron'],
@@ -69,16 +72,15 @@ const config = {
       'browserName': 'electron',
       'wdio:electronServiceOptions': {
         appBinaryPath: binaryPath,
-        appArgs: process.env.ELECTRON_APP_PATH
-          ? [process.env.ELECTRON_APP_PATH, '--no-sandbox', '--disable-gpu']
-          : ['--no-sandbox', '--disable-gpu'],
+        appArgs,
+        chromeDriverArgs: ['--verbose'],
         appEnv: { ZUBRIDGE_MODE: mode },
         browserVersion: electronVersion,
         restoreMocks: true,
       },
     },
   ],
-  waitforTimeout: 5000,
+  waitforTimeout: 15000,
   connectionRetryCount: 10,
   connectionRetryTimeout: 30000,
   logLevel: 'debug',

--- a/packages/electron/docs/api-reference.md
+++ b/packages/electron/docs/api-reference.md
@@ -428,12 +428,12 @@ type ReduxOptions<State extends AnyState> = {
 
 ### `WebContentsWrapper`
 
-Represents any Electron object that has WebContents.
+Represents any Electron object that has WebContents. This includes BrowserWindow, BrowserView, and WebContentsView.
 
 ```ts
 interface WebContentsWrapper {
   webContents: WebContents;
-  isDestroyed(): boolean;
+  isDestroyed?: () => boolean;
 }
 ```
 

--- a/packages/electron/scripts/build.ts
+++ b/packages/electron/scripts/build.ts
@@ -1,12 +1,7 @@
 // Build script for the project
 // Usage: tsx scripts/build.ts
 import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import shell from 'shelljs';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 // compile and bundle
 shell.exec('tsc --project tsconfig.json');

--- a/packages/electron/src/adapters/zustand.ts
+++ b/packages/electron/src/adapters/zustand.ts
@@ -11,6 +11,26 @@ export interface ZustandOptions<S extends AnyState> {
 }
 
 /**
+ * Helper function to find a case-insensitive match in an object
+ */
+function findCaseInsensitiveMatch<T>(obj: Record<string, T>, key: string): [string, T] | undefined {
+  // Try exact match first
+  if (key in obj) {
+    return [key, obj[key]];
+  }
+
+  // Try case-insensitive match
+  const keyLower = key.toLowerCase();
+  const matchingKey = Object.keys(obj).find((k) => k.toLowerCase() === keyLower);
+
+  if (matchingKey) {
+    return [matchingKey, obj[matchingKey]];
+  }
+
+  return undefined;
+}
+
+/**
  * Creates a state manager adapter for Zustand stores
  */
 export function createZustandAdapter<S extends AnyState>(
@@ -23,9 +43,12 @@ export function createZustandAdapter<S extends AnyState>(
     processAction: (action) => {
       try {
         // First check if we have a custom handler for this action type
-        if (options?.handlers && typeof options.handlers[action.type] === 'function') {
-          options.handlers[action.type](action.payload);
-          return;
+        if (options?.handlers) {
+          const handlerMatch = findCaseInsensitiveMatch(options.handlers, action.type);
+          if (handlerMatch && typeof handlerMatch[1] === 'function') {
+            handlerMatch[1](action.payload);
+            return;
+          }
         }
 
         // Next check if we have a reducer
@@ -37,9 +60,17 @@ export function createZustandAdapter<S extends AnyState>(
         // Handle built-in actions
         if (action.type === 'setState') {
           store.setState(action.payload as Partial<S>);
-        } else if (typeof (store.getState() as any)[action.type] === 'function') {
-          // If the action type corresponds to a store method, call it with the payload
-          (store.getState() as any)[action.type](action.payload);
+        } else {
+          // Check for a matching method in the store state
+          const state = store.getState();
+          const methodMatch = findCaseInsensitiveMatch(
+            Object.fromEntries(Object.entries(state).filter(([_, value]) => typeof value === 'function')),
+            action.type,
+          );
+
+          if (methodMatch && typeof methodMatch[1] === 'function') {
+            methodMatch[1](action.payload);
+          }
         }
       } catch (error) {
         console.error('Error processing action:', error);

--- a/packages/electron/src/bridge.ts
+++ b/packages/electron/src/bridge.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import type { BrowserWindow, IpcMainEvent } from 'electron';
+import type { IpcMainEvent, WebContents } from 'electron';
 import type { WebContentsWrapper, Action, StateManager, AnyState, BackendBridge } from '@zubridge/types';
 import { IpcChannel } from './constants';
 import { StoreApi } from 'zustand';
@@ -7,6 +7,15 @@ import { Store } from 'redux';
 import { ZustandOptions } from './adapters/zustand';
 import { ReduxOptions } from './main';
 import { getStateManager } from './utils/stateManagerRegistry';
+import {
+  getWebContents,
+  isDestroyed,
+  safelySendToWindow,
+  createWebContentsTracker,
+  prepareWebContents,
+  WebContentsTracker,
+} from './utils/windows';
+import { sanitizeState } from './utils/serialization';
 
 /**
  * Creates a core bridge between the main process and renderer processes
@@ -14,92 +23,20 @@ import { getStateManager } from './utils/stateManagerRegistry';
  */
 export function createCoreBridge<State extends AnyState>(
   stateManager: StateManager<State>,
-  initialWrappers: WebContentsWrapper[] = [],
+  initialWrappers: Array<WebContentsWrapper | WebContents> = [],
 ): BackendBridge<number> {
-  // This is a mapping from webContents.id to wrapper
-  const wrapperMap = new Map<number, WebContentsWrapper>();
+  // Tracker for WebContents using WeakMap for automatic garbage collection
+  const tracker: WebContentsTracker = createWebContentsTracker();
 
-  // Subscriptions tracks which windows should receive updates
-  const subscriptions = new Set<number>();
-
-  // Helper to safely get webContents id from a wrapper
-  const getWebContentsId = (wrapper: WebContentsWrapper): number | null => {
-    try {
-      if (!wrapper || !wrapper.webContents || wrapper.isDestroyed() || wrapper.webContents.isDestroyed()) {
-        return null;
-      }
-      return wrapper.webContents.id;
-    } catch (error) {
-      return null;
-    }
-  };
-
-  // Helper to safely send a message to a window
-  const safelySendToWindow = (wrapper: WebContentsWrapper, channel: string, data: unknown): boolean => {
-    try {
-      if (!wrapper || !wrapper.webContents || wrapper.isDestroyed() || wrapper.webContents.isDestroyed()) {
-        return false;
-      }
-
-      if (wrapper.webContents.isLoading()) {
-        wrapper.webContents.once('did-finish-load', () => {
-          try {
-            if (!wrapper.webContents.isDestroyed()) {
-              wrapper.webContents.send(channel, data);
-            }
-          } catch (e) {
-            // Ignore errors during load
-          }
-        });
-        return true;
-      }
-
-      wrapper.webContents.send(channel, data);
-      return true;
-    } catch (error) {
-      return false;
-    }
-  };
-
-  // Initialize our wrapper map with initial wrappers
-  for (const wrapper of initialWrappers) {
-    const id = getWebContentsId(wrapper);
-    if (id !== null) {
-      wrapperMap.set(id, wrapper);
-    }
+  // Initialize with initial wrappers
+  const initialWebContents = prepareWebContents(initialWrappers);
+  for (const webContents of initialWebContents) {
+    tracker.track(webContents);
   }
-
-  // Remove destroyed windows from our subscriptions
-  const cleanupDestroyedWindows = () => {
-    const toRemove: number[] = [];
-
-    for (const id of subscriptions) {
-      const wrapper = wrapperMap.get(id);
-      let isValid = false;
-
-      try {
-        isValid = !(!wrapper || wrapper.isDestroyed() || wrapper.webContents.isDestroyed());
-      } catch (e) {
-        // If we get an error, assume the window is destroyed
-        isValid = false;
-      }
-
-      if (!isValid) {
-        toRemove.push(id);
-        wrapperMap.delete(id);
-      }
-    }
-
-    for (const id of toRemove) {
-      subscriptions.delete(id);
-    }
-  };
 
   // Handle dispatch events from renderers
   ipcMain.on(IpcChannel.DISPATCH, (_event: IpcMainEvent, action: Action) => {
     try {
-      cleanupDestroyedWindows();
-
       // Process the action through our state manager
       stateManager.processAction(action);
     } catch (error) {
@@ -107,35 +44,9 @@ export function createCoreBridge<State extends AnyState>(
     }
   });
 
-  /**
-   * Removes functions and non-serializable objects from a state object
-   * to prevent IPC serialization errors
-   */
-  const sanitizeState = (state: AnyState): Record<string, unknown> => {
-    if (!state || typeof state !== 'object') return state as any;
-
-    const safeState: Record<string, unknown> = {};
-
-    for (const key in state) {
-      const value = state[key];
-      // Skip functions which cannot be cloned over IPC
-      if (typeof value !== 'function') {
-        if (value && typeof value === 'object' && !Array.isArray(value)) {
-          // Recursively sanitize nested objects
-          safeState[key] = sanitizeState(value as AnyState);
-        } else {
-          safeState[key] = value;
-        }
-      }
-    }
-
-    return safeState;
-  };
-
   // Handle getState requests from renderers
   ipcMain.handle(IpcChannel.GET_STATE, () => {
     try {
-      cleanupDestroyedWindows();
       return sanitizeState(stateManager.getState());
     } catch (error) {
       console.error('Error handling getState:', error);
@@ -143,23 +54,23 @@ export function createCoreBridge<State extends AnyState>(
     }
   });
 
-  // Subscribe to state manager changes and broadcast to ALL subscribed windows
+  // Subscribe to state manager changes and broadcast to subscribed windows
   const stateManagerUnsubscribe = stateManager.subscribe((state) => {
     try {
-      cleanupDestroyedWindows();
-
-      if (subscriptions.size === 0) {
+      const activeIds = tracker.getActiveIds();
+      if (activeIds.length === 0) {
         return;
       }
 
       // Sanitize state before sending
       const safeState = sanitizeState(state);
 
-      for (const id of subscriptions) {
-        const wrapper = wrapperMap.get(id);
-        if (wrapper) {
-          safelySendToWindow(wrapper, IpcChannel.SUBSCRIBE, safeState);
-        }
+      // Get active WebContents from our tracker
+      const activeWebContents = tracker.getActiveWebContents();
+
+      // Send updates to all active WebContents that were explicitly subscribed
+      for (const webContents of activeWebContents) {
+        safelySendToWindow(webContents, IpcChannel.SUBSCRIBE, safeState);
       }
     } catch (error) {
       console.error('Error in state subscription handler:', error);
@@ -167,68 +78,60 @@ export function createCoreBridge<State extends AnyState>(
   });
 
   // Add new windows to tracking and subscriptions
-  const subscribe = (newWrappers: WebContentsWrapper[]): { unsubscribe: () => void } => {
-    const addedIds: number[] = [];
+  const subscribe = (newWrappers: Array<WebContentsWrapper | WebContents>): { unsubscribe: () => void } => {
+    const addedWebContents: WebContents[] = [];
 
     // Handle invalid input cases
     if (!newWrappers || !Array.isArray(newWrappers)) {
       return { unsubscribe: () => {} };
     }
 
+    // Get WebContents from wrappers and track them
     for (const wrapper of newWrappers) {
-      const id = getWebContentsId(wrapper);
-      if (id === null) continue;
-
-      // Add to our maps
-      wrapperMap.set(id, wrapper);
-      subscriptions.add(id);
-      addedIds.push(id);
-
-      // Set up automatic cleanup when the window is destroyed
-      try {
-        wrapper.webContents.once('destroyed', () => {
-          subscriptions.delete(id);
-          wrapperMap.delete(id);
-        });
-      } catch (e) {
-        // Ignore errors during setup
+      const webContents = getWebContents(wrapper);
+      if (!webContents || isDestroyed(webContents)) {
+        continue;
       }
 
-      // Send initial state
-      const currentState = sanitizeState(stateManager.getState());
-      safelySendToWindow(wrapper, IpcChannel.SUBSCRIBE, currentState);
+      // Track the WebContents
+      if (tracker.track(webContents)) {
+        addedWebContents.push(webContents);
+
+        // Send initial state
+        const currentState = sanitizeState(stateManager.getState());
+        safelySendToWindow(webContents, IpcChannel.SUBSCRIBE, currentState);
+      }
     }
 
     // Return an unsubscribe function
     return {
       unsubscribe: () => {
-        for (const id of addedIds) {
-          subscriptions.delete(id);
+        for (const webContents of addedWebContents) {
+          tracker.untrack(webContents);
         }
       },
     };
   };
 
   // Remove windows from subscriptions
-  const unsubscribe = (unwrappers?: WebContentsWrapper[]) => {
+  const unsubscribe = (unwrappers?: Array<WebContentsWrapper | WebContents>) => {
     if (!unwrappers) {
       // If no wrappers are provided, unsubscribe all
-      subscriptions.clear();
+      tracker.cleanup();
       return;
     }
 
     for (const wrapper of unwrappers) {
-      const id = getWebContentsId(wrapper);
-      if (id !== null) {
-        subscriptions.delete(id);
+      const webContents = getWebContents(wrapper);
+      if (webContents) {
+        tracker.untrack(webContents);
       }
     }
   };
 
   // Get the list of currently subscribed window IDs
   const getSubscribedWindows = (): number[] => {
-    cleanupDestroyedWindows();
-    return [...subscriptions];
+    return tracker.getActiveIds();
   };
 
   // Cleanup function to remove all listeners
@@ -237,14 +140,8 @@ export function createCoreBridge<State extends AnyState>(
     ipcMain.removeHandler(IpcChannel.GET_STATE);
     // We can't remove the "on" listener cleanly in Electron,
     // but we can ensure we don't process any more dispatches
-    subscriptions.clear();
-    wrapperMap.clear();
+    tracker.cleanup();
   };
-
-  // Subscribe the initial wrappers
-  if (initialWrappers.length > 0) {
-    subscribe(initialWrappers);
-  }
 
   return {
     subscribe,
@@ -261,7 +158,7 @@ export function createCoreBridge<State extends AnyState>(
  */
 export function createBridgeFromStore<S extends AnyState = AnyState>(
   store: StoreApi<S> | Store<S>,
-  windows: Array<BrowserWindow | WebContentsWrapper> = [],
+  windows: Array<WebContentsWrapper | WebContents> = [],
   options?: ZustandOptions<S> | ReduxOptions<S>,
 ): BackendBridge<number> {
   // Get or create a state manager for the store

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -1,4 +1,4 @@
-import type { BrowserWindow } from 'electron';
+import type { BrowserWindow, WebContents } from 'electron';
 import type { Store } from 'redux';
 import type { StoreApi } from 'zustand/vanilla';
 import type { BackendBridge, WebContentsWrapper, AnyState, Dispatch } from '@zubridge/types';
@@ -34,7 +34,7 @@ export interface ZustandBridge<S extends AnyState = AnyState> extends BackendBri
  */
 export function createZustandBridge<S extends AnyState>(
   store: StoreApi<S>,
-  windows: Array<BrowserWindow | WebContentsWrapper> = [],
+  windows: Array<WebContentsWrapper | WebContents> = [],
   options?: ZustandOptions<S>,
 ): ZustandBridge<S> {
   // Create the core bridge with the store
@@ -61,8 +61,8 @@ export function createZustandBridge<S extends AnyState>(
  * Interface for a bridge that connects a Redux store to the main process
  */
 export interface ReduxBridge<S extends AnyState = AnyState> extends BackendBridge<number> {
-  subscribe: (windows: Array<BrowserWindow | WebContentsWrapper>) => { unsubscribe: () => void };
-  unsubscribe: (windows?: Array<BrowserWindow | WebContentsWrapper>) => void;
+  subscribe: (windows: Array<WebContentsWrapper | WebContents>) => { unsubscribe: () => void };
+  unsubscribe: (windows?: Array<WebContentsWrapper | WebContents>) => void;
   getSubscribedWindows: () => number[];
   dispatch: Dispatch<S>;
   destroy: () => void;
@@ -73,7 +73,7 @@ export interface ReduxBridge<S extends AnyState = AnyState> extends BackendBridg
  */
 export function createReduxBridge<S extends AnyState>(
   store: Store<S>,
-  windows: Array<BrowserWindow | WebContentsWrapper> = [],
+  windows: Array<WebContentsWrapper | WebContents> = [],
   options?: ReduxOptions<S>,
 ): ReduxBridge<S> {
   // Create the core bridge with the store

--- a/packages/electron/src/utils/serialization.ts
+++ b/packages/electron/src/utils/serialization.ts
@@ -1,0 +1,30 @@
+import type { AnyState } from '@zubridge/types';
+
+/**
+ * Removes functions and non-serializable objects from a state object
+ * to prevent IPC serialization errors when sending between processes
+ *
+ * @param state The state object to sanitize
+ * @returns A new state object with functions and non-serializable parts removed
+ */
+export const sanitizeState = (state: AnyState): Record<string, unknown> => {
+  if (!state || typeof state !== 'object') return state as any;
+
+  const safeState: Record<string, unknown> = {};
+
+  for (const key in state) {
+    const value = state[key];
+
+    // Skip functions which cannot be cloned over IPC
+    if (typeof value !== 'function') {
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        // Recursively sanitize nested objects
+        safeState[key] = sanitizeState(value as AnyState);
+      } else {
+        safeState[key] = value;
+      }
+    }
+  }
+
+  return safeState;
+};

--- a/packages/electron/src/utils/windows.ts
+++ b/packages/electron/src/utils/windows.ts
@@ -1,0 +1,221 @@
+import type { WebContents } from 'electron';
+import type { WebContentsWrapper } from '@zubridge/types';
+
+/**
+ * Type guard to check if an object is an Electron WebContents
+ */
+export const isWebContents = (
+  wrapperOrWebContents: WebContentsWrapper | WebContents,
+): wrapperOrWebContents is WebContents => {
+  return typeof wrapperOrWebContents === 'object' && 'id' in wrapperOrWebContents;
+};
+
+/**
+ * Type guard to check if an object is a WebContentsWrapper
+ */
+export const isWrapper = (
+  wrapperOrWebContents: WebContentsWrapper | WebContents,
+): wrapperOrWebContents is WebContentsWrapper => {
+  return typeof wrapperOrWebContents === 'object' && 'webContents' in wrapperOrWebContents;
+};
+
+/**
+ * Get the WebContents object from either a WebContentsWrapper or WebContents
+ */
+export const getWebContents = (wrapperOrWebContents: WebContentsWrapper | WebContents): WebContents | undefined => {
+  if (isWebContents(wrapperOrWebContents)) {
+    return wrapperOrWebContents;
+  }
+
+  if (isWrapper(wrapperOrWebContents)) {
+    return wrapperOrWebContents.webContents;
+  }
+
+  return undefined;
+};
+
+/**
+ * Check if a WebContents is destroyed
+ */
+export const isDestroyed = (webContents: WebContents): boolean => {
+  try {
+    if (typeof webContents.isDestroyed === 'function') {
+      return webContents.isDestroyed();
+    }
+    return false;
+  } catch (error) {
+    return true;
+  }
+};
+
+/**
+ * Safely send a message to a WebContents
+ */
+export const safelySendToWindow = (webContents: WebContents, channel: string, data: unknown): boolean => {
+  try {
+    if (!webContents || isDestroyed(webContents)) {
+      return false;
+    }
+
+    // Type check for WebContents API
+    const hasWebContentsAPI = typeof webContents.send === 'function';
+    if (!hasWebContentsAPI) {
+      return false;
+    }
+
+    // Check if isLoading is a function before calling it
+    const isLoading = typeof webContents.isLoading === 'function' ? webContents.isLoading() : false;
+
+    if (isLoading) {
+      webContents.once('did-finish-load', () => {
+        try {
+          if (!webContents.isDestroyed()) {
+            webContents.send(channel, data);
+          }
+        } catch (e) {
+          // Ignore errors during load
+        }
+      });
+      return true;
+    }
+
+    webContents.send(channel, data);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+/**
+ * Set up cleanup when WebContents is destroyed
+ */
+export const setupDestroyListener = (webContents: WebContents, cleanup: () => void): void => {
+  try {
+    if (typeof webContents.once === 'function') {
+      webContents.once('destroyed', cleanup);
+    }
+  } catch (e) {
+    // Ignore errors
+  }
+};
+
+/**
+ * Creates a tracker for WebContents objects using WeakMap for automatic garbage collection
+ * and a Set to keep track of active IDs
+ */
+export interface WebContentsTracker {
+  track(webContents: WebContents): boolean;
+  untrack(webContents: WebContents): void;
+  untrackById(id: number): void;
+  isTracked(webContents: WebContents): boolean;
+  hasId(id: number): boolean;
+  getActiveIds(): number[];
+  getActiveWebContents(): WebContents[];
+  cleanup(): void;
+}
+
+/**
+ * Creates a WebContents tracker that uses WeakMap for automatic garbage collection
+ * but maintains a set of active IDs for tracking purposes
+ */
+export const createWebContentsTracker = (): WebContentsTracker => {
+  // WeakMap for the primary storage - won't prevent garbage collection
+  const webContentsTracker = new WeakMap<WebContents, { id: number }>();
+
+  // Set to track active subscription IDs (not object references)
+  const activeIds = new Set<number>();
+
+  // Strong reference map of WebContents by ID - we need this to retrieve active WebContents
+  // This will be maintained alongside the WeakMap
+  const webContentsById = new Map<number, WebContents>();
+
+  return {
+    track: (webContents: WebContents): boolean => {
+      if (!webContents || isDestroyed(webContents)) return false;
+
+      const id = webContents.id;
+      webContentsTracker.set(webContents, { id });
+      activeIds.add(id);
+      webContentsById.set(id, webContents);
+
+      // Set up the destroyed listener for cleanup
+      setupDestroyListener(webContents, () => {
+        activeIds.delete(id);
+        webContentsTracker.delete(webContents);
+        webContentsById.delete(id);
+      });
+
+      return true;
+    },
+
+    untrack: (webContents: WebContents): void => {
+      if (!webContents) return;
+
+      const id = webContents.id;
+      // Explicitly delete from all tracking structures
+      webContentsTracker.delete(webContents);
+      activeIds.delete(id);
+      webContentsById.delete(id);
+    },
+
+    untrackById: (id: number): void => {
+      activeIds.delete(id);
+      const webContents = webContentsById.get(id);
+      if (webContents) {
+        webContentsTracker.delete(webContents);
+      }
+      webContentsById.delete(id);
+    },
+
+    isTracked: (webContents: WebContents): boolean => {
+      return webContents && webContentsTracker.has(webContents) && activeIds.has(webContents.id);
+    },
+
+    hasId: (id: number): boolean => {
+      return activeIds.has(id);
+    },
+
+    getActiveIds: (): number[] => {
+      return [...activeIds];
+    },
+
+    getActiveWebContents: (): WebContents[] => {
+      const result: WebContents[] = [];
+
+      // Filter out any destroyed WebContents that might still be in our map
+      for (const [id, webContents] of webContentsById.entries()) {
+        if (!isDestroyed(webContents)) {
+          result.push(webContents);
+        } else {
+          // Clean up any destroyed WebContents we find
+          activeIds.delete(id);
+          webContentsById.delete(id);
+        }
+      }
+
+      return result;
+    },
+
+    cleanup: (): void => {
+      activeIds.clear();
+      webContentsById.clear();
+    },
+  };
+};
+
+/**
+ * Helper function to prepare a batch of WebContents objects for tracking
+ * from various input types
+ */
+export const prepareWebContents = (wrappers: Array<WebContentsWrapper | WebContents>): WebContents[] => {
+  const result: WebContents[] = [];
+
+  for (const wrapper of wrappers) {
+    const webContents = getWebContents(wrapper);
+    if (webContents && !isDestroyed(webContents)) {
+      result.push(webContents);
+    }
+  }
+
+  return result;
+};

--- a/packages/electron/src/utils/windows.ts
+++ b/packages/electron/src/utils/windows.ts
@@ -7,7 +7,7 @@ import type { WebContentsWrapper } from '@zubridge/types';
 export const isWebContents = (
   wrapperOrWebContents: WebContentsWrapper | WebContents,
 ): wrapperOrWebContents is WebContents => {
-  return typeof wrapperOrWebContents === 'object' && 'id' in wrapperOrWebContents;
+  return wrapperOrWebContents && typeof wrapperOrWebContents === 'object' && 'id' in wrapperOrWebContents;
 };
 
 /**
@@ -16,7 +16,7 @@ export const isWebContents = (
 export const isWrapper = (
   wrapperOrWebContents: WebContentsWrapper | WebContents,
 ): wrapperOrWebContents is WebContentsWrapper => {
-  return typeof wrapperOrWebContents === 'object' && 'webContents' in wrapperOrWebContents;
+  return wrapperOrWebContents && typeof wrapperOrWebContents === 'object' && 'webContents' in wrapperOrWebContents;
 };
 
 /**

--- a/packages/electron/src/utils/windows.ts
+++ b/packages/electron/src/utils/windows.ts
@@ -1,13 +1,25 @@
 import type { WebContents } from 'electron';
 import type { WebContentsWrapper } from '@zubridge/types';
 
+// Debug logger with timestamp
+const debugWindows = (message: string, ...args: any[]) => {
+  const timestamp = new Date().toISOString();
+  console.log(`[WINDOWS ${timestamp}] ${message}`, ...args);
+};
+
 /**
  * Type guard to check if an object is an Electron WebContents
  */
 export const isWebContents = (
   wrapperOrWebContents: WebContentsWrapper | WebContents,
 ): wrapperOrWebContents is WebContents => {
-  return wrapperOrWebContents && typeof wrapperOrWebContents === 'object' && 'id' in wrapperOrWebContents;
+  const result = wrapperOrWebContents && typeof wrapperOrWebContents === 'object' && 'id' in wrapperOrWebContents;
+  if (result) {
+    debugWindows(`isWebContents: TRUE for id ${(wrapperOrWebContents as WebContents).id}`);
+  } else {
+    debugWindows('isWebContents: FALSE', wrapperOrWebContents);
+  }
+  return result;
 };
 
 /**
@@ -16,21 +28,48 @@ export const isWebContents = (
 export const isWrapper = (
   wrapperOrWebContents: WebContentsWrapper | WebContents,
 ): wrapperOrWebContents is WebContentsWrapper => {
-  return wrapperOrWebContents && typeof wrapperOrWebContents === 'object' && 'webContents' in wrapperOrWebContents;
+  const result =
+    wrapperOrWebContents && typeof wrapperOrWebContents === 'object' && 'webContents' in wrapperOrWebContents;
+
+  if (result) {
+    debugWindows(`isWrapper: TRUE for id ${(wrapperOrWebContents as WebContentsWrapper).webContents?.id}`);
+  } else {
+    debugWindows('isWrapper: FALSE', wrapperOrWebContents);
+  }
+  return result;
 };
 
 /**
  * Get the WebContents object from either a WebContentsWrapper or WebContents
  */
 export const getWebContents = (wrapperOrWebContents: WebContentsWrapper | WebContents): WebContents | undefined => {
+  // Create a more readable description of the input for logging
+  let description = 'Invalid input';
+
+  if (wrapperOrWebContents && typeof wrapperOrWebContents === 'object') {
+    if ('id' in wrapperOrWebContents) {
+      description = `WebContents ID: ${wrapperOrWebContents.id}`;
+    } else if ('webContents' in wrapperOrWebContents) {
+      description = `Wrapper with WebContents ID: ${wrapperOrWebContents.webContents?.id}`;
+    } else {
+      description = 'Unknown object type';
+    }
+  }
+
+  debugWindows(`getWebContents called with: ${description}`);
+
   if (isWebContents(wrapperOrWebContents)) {
+    debugWindows(`getWebContents: Returning direct WebContents with ID: ${wrapperOrWebContents.id}`);
     return wrapperOrWebContents;
   }
 
   if (isWrapper(wrapperOrWebContents)) {
-    return wrapperOrWebContents.webContents;
+    const webContents = wrapperOrWebContents.webContents;
+    debugWindows(`getWebContents: Extracting from wrapper, ID: ${webContents?.id || 'undefined'}`);
+    return webContents;
   }
 
+  debugWindows('getWebContents: Could not extract WebContents, returning undefined');
   return undefined;
 };
 
@@ -40,10 +79,14 @@ export const getWebContents = (wrapperOrWebContents: WebContentsWrapper | WebCon
 export const isDestroyed = (webContents: WebContents): boolean => {
   try {
     if (typeof webContents.isDestroyed === 'function') {
-      return webContents.isDestroyed();
+      const destroyed = webContents.isDestroyed();
+      debugWindows(`isDestroyed check for WebContents ID ${webContents.id}: ${destroyed}`);
+      return destroyed;
     }
+    debugWindows(`isDestroyed: WebContents ID ${webContents?.id} has no isDestroyed function`);
     return false;
   } catch (error) {
+    debugWindows(`isDestroyed: Exception while checking ID ${webContents?.id}`, error);
     return true;
   }
 };
@@ -53,35 +96,46 @@ export const isDestroyed = (webContents: WebContents): boolean => {
  */
 export const safelySendToWindow = (webContents: WebContents, channel: string, data: unknown): boolean => {
   try {
+    debugWindows(`safelySendToWindow: Attempting to send to WebContents ID ${webContents?.id}, channel: ${channel}`);
+
     if (!webContents || isDestroyed(webContents)) {
+      debugWindows(`safelySendToWindow: WebContents is undefined or destroyed, aborting send`);
       return false;
     }
 
     // Type check for WebContents API
     const hasWebContentsAPI = typeof webContents.send === 'function';
     if (!hasWebContentsAPI) {
+      debugWindows(`safelySendToWindow: WebContents ID ${webContents.id} missing 'send' function`);
       return false;
     }
 
     // Check if isLoading is a function before calling it
     const isLoading = typeof webContents.isLoading === 'function' ? webContents.isLoading() : false;
+    debugWindows(`safelySendToWindow: WebContents ID ${webContents.id} isLoading: ${isLoading}`);
 
     if (isLoading) {
+      debugWindows(`safelySendToWindow: WebContents ID ${webContents.id} is loading, queueing message for later`);
       webContents.once('did-finish-load', () => {
         try {
           if (!webContents.isDestroyed()) {
+            debugWindows(`safelySendToWindow: Now sending delayed message to WebContents ID ${webContents.id}`);
             webContents.send(channel, data);
+          } else {
+            debugWindows(`safelySendToWindow: WebContents ID ${webContents.id} was destroyed before load finished`);
           }
         } catch (e) {
-          // Ignore errors during load
+          debugWindows(`safelySendToWindow: Error sending delayed message to WebContents ID ${webContents.id}`, e);
         }
       });
       return true;
     }
 
+    debugWindows(`safelySendToWindow: Sending message immediately to WebContents ID ${webContents.id}`);
     webContents.send(channel, data);
     return true;
   } catch (error) {
+    debugWindows(`safelySendToWindow: Exception while sending to WebContents ID ${webContents?.id}`, error);
     return false;
   }
 };
@@ -91,11 +145,17 @@ export const safelySendToWindow = (webContents: WebContents, channel: string, da
  */
 export const setupDestroyListener = (webContents: WebContents, cleanup: () => void): void => {
   try {
+    debugWindows(`setupDestroyListener: Setting up cleanup for WebContents ID ${webContents?.id}`);
     if (typeof webContents.once === 'function') {
-      webContents.once('destroyed', cleanup);
+      webContents.once('destroyed', () => {
+        debugWindows(`WebContents ID ${webContents.id} destroyed, running cleanup`);
+        cleanup();
+      });
+    } else {
+      debugWindows(`setupDestroyListener: WebContents ID ${webContents.id} missing 'once' function`);
     }
   } catch (e) {
-    // Ignore errors
+    debugWindows(`setupDestroyListener: Exception for WebContents ID ${webContents?.id}`, e);
   }
 };
 
@@ -119,6 +179,8 @@ export interface WebContentsTracker {
  * but maintains a set of active IDs for tracking purposes
  */
 export const createWebContentsTracker = (): WebContentsTracker => {
+  debugWindows('Creating new WebContentsTracker');
+
   // WeakMap for the primary storage - won't prevent garbage collection
   const webContentsTracker = new WeakMap<WebContents, { id: number }>();
 
@@ -129,74 +191,119 @@ export const createWebContentsTracker = (): WebContentsTracker => {
   // This will be maintained alongside the WeakMap
   const webContentsById = new Map<number, WebContents>();
 
+  const logTrackerState = () => {
+    debugWindows(`WebContentsTracker state: ${activeIds.size} active IDs, ${webContentsById.size} tracked WebContents`);
+    debugWindows(`Active IDs: ${[...activeIds].join(', ')}`);
+  };
+
   return {
     track: (webContents: WebContents): boolean => {
-      if (!webContents || isDestroyed(webContents)) return false;
+      if (!webContents) {
+        debugWindows('track: Called with undefined WebContents');
+        return false;
+      }
+
+      if (isDestroyed(webContents)) {
+        debugWindows(`track: WebContents ID ${webContents.id} is already destroyed`);
+        return false;
+      }
 
       const id = webContents.id;
+      debugWindows(`track: Adding WebContents ID ${id} to tracker`);
+
       webContentsTracker.set(webContents, { id });
       activeIds.add(id);
       webContentsById.set(id, webContents);
 
       // Set up the destroyed listener for cleanup
       setupDestroyListener(webContents, () => {
+        debugWindows(`track: Cleanup handler for WebContents ID ${id} triggered`);
         activeIds.delete(id);
-        webContentsTracker.delete(webContents);
         webContentsById.delete(id);
       });
 
+      logTrackerState();
       return true;
     },
 
     untrack: (webContents: WebContents): void => {
-      if (!webContents) return;
+      if (!webContents) {
+        debugWindows('untrack: Called with undefined WebContents');
+        return;
+      }
 
       const id = webContents.id;
+      debugWindows(`untrack: Removing WebContents ID ${id} from tracker`);
+
       // Explicitly delete from all tracking structures
       webContentsTracker.delete(webContents);
       activeIds.delete(id);
       webContentsById.delete(id);
+
+      logTrackerState();
     },
 
     untrackById: (id: number): void => {
+      debugWindows(`untrackById: Removing ID ${id} from tracker`);
+
       activeIds.delete(id);
       const webContents = webContentsById.get(id);
       if (webContents) {
+        debugWindows(`untrackById: Found and removing WebContents for ID ${id}`);
         webContentsTracker.delete(webContents);
       }
       webContentsById.delete(id);
+
+      logTrackerState();
     },
 
     isTracked: (webContents: WebContents): boolean => {
-      return webContents && webContentsTracker.has(webContents) && activeIds.has(webContents.id);
+      if (!webContents) {
+        debugWindows('isTracked: Called with undefined WebContents');
+        return false;
+      }
+
+      const tracked = webContents && webContentsTracker.has(webContents) && activeIds.has(webContents.id);
+
+      debugWindows(`isTracked: WebContents ID ${webContents.id} tracked: ${tracked}`);
+      return tracked;
     },
 
     hasId: (id: number): boolean => {
-      return activeIds.has(id);
+      const has = activeIds.has(id);
+      debugWindows(`hasId: ID ${id} in tracker: ${has}`);
+      return has;
     },
 
     getActiveIds: (): number[] => {
-      return [...activeIds];
+      const ids = [...activeIds];
+      debugWindows(`getActiveIds: Returning ${ids.length} active IDs: ${ids.join(', ')}`);
+      return ids;
     },
 
     getActiveWebContents: (): WebContents[] => {
+      debugWindows('getActiveWebContents: Collecting active WebContents');
       const result: WebContents[] = [];
 
       // Filter out any destroyed WebContents that might still be in our map
       for (const [id, webContents] of webContentsById.entries()) {
         if (!isDestroyed(webContents)) {
+          debugWindows(`getActiveWebContents: Adding active WebContents ID ${id}`);
           result.push(webContents);
         } else {
           // Clean up any destroyed WebContents we find
+          debugWindows(`getActiveWebContents: Found destroyed WebContents ID ${id}, cleaning up`);
           activeIds.delete(id);
           webContentsById.delete(id);
         }
       }
 
+      debugWindows(`getActiveWebContents: Returning ${result.length} active WebContents`);
       return result;
     },
 
     cleanup: (): void => {
+      debugWindows(`cleanup: Clearing all tracked WebContents (${activeIds.size} IDs)`);
       activeIds.clear();
       webContentsById.clear();
     },
@@ -208,14 +315,19 @@ export const createWebContentsTracker = (): WebContentsTracker => {
  * from various input types
  */
 export const prepareWebContents = (wrappers: Array<WebContentsWrapper | WebContents>): WebContents[] => {
+  debugWindows(`prepareWebContents: Processing ${wrappers.length} wrappers/WebContents`);
   const result: WebContents[] = [];
 
   for (const wrapper of wrappers) {
     const webContents = getWebContents(wrapper);
     if (webContents && !isDestroyed(webContents)) {
+      debugWindows(`prepareWebContents: Adding WebContents ID ${webContents.id} to result`);
       result.push(webContents);
+    } else {
+      debugWindows('prepareWebContents: Skipping undefined or destroyed WebContents');
     }
   }
 
+  debugWindows(`prepareWebContents: Returning ${result.length} valid WebContents objects`);
   return result;
 };

--- a/packages/electron/test/adapters/zustand.spec.ts
+++ b/packages/electron/test/adapters/zustand.spec.ts
@@ -78,6 +78,25 @@ describe('Zustand Adapter', () => {
       expect(customHandler).toHaveBeenCalledWith('test-data');
       expect(store.setState).not.toHaveBeenCalled();
     });
+
+    it('should call custom handlers with case-insensitive matching', () => {
+      const incrementHandler = vi.fn();
+      const decrementHandler = vi.fn();
+      const adapterWithHandlers = createZustandAdapter(store, {
+        handlers: {
+          increment: incrementHandler,
+          DECREMENT: decrementHandler,
+        },
+      });
+
+      // Test uppercase action with lowercase handler
+      adapterWithHandlers.processAction({ type: 'INCREMENT', payload: 5 });
+      expect(incrementHandler).toHaveBeenCalledWith(5);
+
+      // Test lowercase action with uppercase handler
+      adapterWithHandlers.processAction({ type: 'decrement', payload: 3 });
+      expect(decrementHandler).toHaveBeenCalledWith(3);
+    });
   });
 
   describe('processAction with reducer', () => {
@@ -119,6 +138,33 @@ describe('Zustand Adapter', () => {
       testAdapter.processAction(action);
 
       expect(setCountMock).toHaveBeenCalledWith(99);
+    });
+
+    it('should call store methods with case-insensitive matching', () => {
+      const incrementMock = vi.fn();
+      const decrementMock = vi.fn();
+      const resetMock = vi.fn();
+
+      const testStore = createMockZustandStore({
+        count: 0,
+        increment: incrementMock,
+        decrement: decrementMock,
+        resetCounter: resetMock,
+      });
+
+      const testAdapter = createZustandAdapter(testStore);
+
+      // Test uppercase action with lowercase method
+      testAdapter.processAction({ type: 'INCREMENT', payload: 5 });
+      expect(incrementMock).toHaveBeenCalledWith(5);
+
+      // Test mixed case action with lowercase method
+      testAdapter.processAction({ type: 'DeCreMeNt', payload: 3 });
+      expect(decrementMock).toHaveBeenCalledWith(3);
+
+      // Test lowercase action with camelCase method
+      testAdapter.processAction({ type: 'resetcounter' });
+      expect(resetMock).toHaveBeenCalled();
     });
   });
 

--- a/packages/electron/test/serialization.spec.ts
+++ b/packages/electron/test/serialization.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeState } from '../src/utils/serialization.js';
+
+describe('serialization.ts', () => {
+  describe('sanitizeState', () => {
+    it('should handle primitive values', () => {
+      expect(sanitizeState(null as any)).toBeNull();
+      expect(sanitizeState(undefined as any)).toBeUndefined();
+      expect(sanitizeState(42 as any)).toBe(42);
+      expect(sanitizeState('hello' as any)).toBe('hello');
+      expect(sanitizeState(true as any)).toBe(true);
+    });
+
+    it('should remove functions from objects', () => {
+      const input = {
+        name: 'test',
+        age: 30,
+        callback: () => console.log('hello'),
+      };
+
+      const output = sanitizeState(input);
+
+      expect(output).toEqual({
+        name: 'test',
+        age: 30,
+      });
+      expect(output).not.toHaveProperty('callback');
+    });
+
+    it('should handle nested objects', () => {
+      const input = {
+        user: {
+          name: 'John',
+          sayHello: () => 'Hello',
+          details: {
+            age: 30,
+            getAge: () => 30,
+          },
+        },
+        items: [1, 2, 3],
+      };
+
+      const output = sanitizeState(input);
+
+      expect(output).toEqual({
+        user: {
+          name: 'John',
+          details: {
+            age: 30,
+          },
+        },
+        items: [1, 2, 3],
+      });
+
+      expect(output.user).not.toHaveProperty('sayHello');
+      expect((output.user as any).details).not.toHaveProperty('getAge');
+    });
+
+    it('should preserve arrays with functions', () => {
+      const input = {
+        items: [1, 2, 3, () => {}],
+        callbacks: [() => {}, () => {}],
+      };
+
+      const output = sanitizeState(input);
+
+      // Verify array properties exist
+      expect(output).toHaveProperty('items');
+      expect(output).toHaveProperty('callbacks');
+
+      // Verify arrays are maintained
+      expect(Array.isArray(output.items)).toBe(true);
+      expect(Array.isArray(output.callbacks)).toBe(true);
+
+      // Verify primitive values in arrays
+      expect(output.items).toContain(1);
+      expect(output.items).toContain(2);
+      expect(output.items).toContain(3);
+
+      // Verify array lengths
+      expect(output.items).toHaveLength(4);
+      expect(output.callbacks).toHaveLength(2);
+    });
+
+    it('should correctly handle complex object structures', () => {
+      const input = {
+        data: {
+          users: [
+            { id: 1, name: 'Alice', getInfo: () => {} },
+            { id: 2, name: 'Bob', getInfo: () => {} },
+          ],
+          settings: {
+            theme: 'dark',
+            toggleTheme: () => {},
+          },
+        },
+        helpers: {
+          format: () => {},
+          validate: () => {},
+        },
+      };
+
+      const output = sanitizeState(input);
+
+      // Test user structure
+      expect(output).toHaveProperty('data');
+      expect(output.data).toHaveProperty('users');
+      expect(output.data).toHaveProperty('settings');
+
+      // Verify settings
+      expect((output.data as any).settings).toHaveProperty('theme', 'dark');
+      expect((output.data as any).settings).not.toHaveProperty('toggleTheme');
+
+      // Verify users array
+      const users = (output.data as any).users;
+      expect(Array.isArray(users)).toBe(true);
+      expect(users).toHaveLength(2);
+
+      // Check user properties
+      expect(users[0]).toHaveProperty('id', 1);
+      expect(users[0]).toHaveProperty('name', 'Alice');
+      expect(users[1]).toHaveProperty('id', 2);
+      expect(users[1]).toHaveProperty('name', 'Bob');
+
+      // Check if helpers exists (it should, but be empty)
+      expect(output).toHaveProperty('helpers');
+      expect(Object.keys(output.helpers as object)).toHaveLength(0);
+    });
+  });
+});

--- a/packages/electron/test/windows.spec.ts
+++ b/packages/electron/test/windows.spec.ts
@@ -227,7 +227,11 @@ describe('windows.ts', () => {
 
       setupDestroyListener(webContents, cleanup);
 
-      expect(webContents.once).toHaveBeenCalledWith('destroyed', cleanup);
+      expect(webContents.once).toHaveBeenCalledWith('destroyed', expect.any(Function));
+
+      const onceCallback = vi.mocked(webContents.once).mock.calls[0][1] as Function;
+      onceCallback();
+      expect(cleanup).toHaveBeenCalled();
     });
 
     it('should handle WebContents without an once function', () => {

--- a/packages/electron/test/windows.spec.ts
+++ b/packages/electron/test/windows.spec.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WebContents } from 'electron';
+import type { WebContentsWrapper } from '@zubridge/types';
+import {
+  isWebContents,
+  isWrapper,
+  getWebContents,
+  isDestroyed,
+  safelySendToWindow,
+  setupDestroyListener,
+  createWebContentsTracker,
+  prepareWebContents,
+} from '../src/utils/windows';
+
+// Create mock WebContents object
+function mockWebContents(id = 1, destroyed = false): WebContents {
+  return {
+    id,
+    isDestroyed: vi.fn(() => destroyed),
+    isLoading: vi.fn(() => false),
+    send: vi.fn(),
+    once: vi.fn(),
+  } as unknown as WebContents;
+}
+
+// Create mock WebContentsWrapper object
+function mockWrapper(id = 1, destroyed = false, webContentsDestroyed = false): WebContentsWrapper {
+  return {
+    webContents: mockWebContents(id, webContentsDestroyed),
+    isDestroyed: vi.fn(() => destroyed),
+  };
+}
+
+describe('windows.ts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isWebContents', () => {
+    it('should return true for WebContents objects', () => {
+      const webContents = mockWebContents();
+      expect(isWebContents(webContents)).toBe(true);
+    });
+
+    it('should return false for wrapper objects', () => {
+      const wrapper = mockWrapper();
+      expect(isWebContents(wrapper)).toBe(false);
+    });
+  });
+
+  describe('isWrapper', () => {
+    it('should return true for wrapper objects', () => {
+      const wrapper = mockWrapper();
+      expect(isWrapper(wrapper)).toBe(true);
+    });
+
+    it('should return false for WebContents objects', () => {
+      const webContents = mockWebContents();
+      expect(isWrapper(webContents)).toBe(false);
+    });
+  });
+
+  describe('getWebContents', () => {
+    it('should return WebContents from a WebContents object', () => {
+      const webContents = mockWebContents();
+      expect(getWebContents(webContents)).toBe(webContents);
+    });
+
+    it('should return WebContents from a wrapper object', () => {
+      const wrapper = mockWrapper();
+      expect(getWebContents(wrapper)).toBe(wrapper.webContents);
+    });
+
+    it('should return undefined for invalid input', () => {
+      expect(getWebContents(null as any)).toBeUndefined();
+      expect(getWebContents(undefined as any)).toBeUndefined();
+      expect(getWebContents({} as any)).toBeUndefined();
+    });
+  });
+
+  describe('isDestroyed', () => {
+    it('should return true for destroyed WebContents', () => {
+      const webContents = mockWebContents(1, true);
+      expect(isDestroyed(webContents)).toBe(true);
+    });
+
+    it('should return false for active WebContents', () => {
+      const webContents = mockWebContents(1, false);
+      expect(isDestroyed(webContents)).toBe(false);
+    });
+
+    it('should return true if isDestroyed throws an error', () => {
+      const webContents = mockWebContents();
+      vi.mocked(webContents.isDestroyed).mockImplementation(() => {
+        throw new Error('Test error');
+      });
+      expect(isDestroyed(webContents)).toBe(true);
+    });
+  });
+
+  describe('safelySendToWindow', () => {
+    it('should send message to active WebContents', () => {
+      const webContents = mockWebContents();
+      const result = safelySendToWindow(webContents, 'test-channel', { data: 'test' });
+
+      expect(result).toBe(true);
+      expect(webContents.send).toHaveBeenCalledWith('test-channel', { data: 'test' });
+    });
+
+    it('should not send to destroyed WebContents', () => {
+      const webContents = mockWebContents(1, true);
+      const result = safelySendToWindow(webContents, 'test-channel', { data: 'test' });
+
+      expect(result).toBe(false);
+      expect(webContents.send).not.toHaveBeenCalled();
+    });
+
+    it('should handle loading WebContents by setting up a listener', () => {
+      const webContents = mockWebContents();
+      vi.mocked(webContents.isLoading).mockReturnValue(true);
+
+      const result = safelySendToWindow(webContents, 'test-channel', { data: 'test' });
+
+      expect(result).toBe(true);
+      expect(webContents.once).toHaveBeenCalledWith('did-finish-load', expect.any(Function));
+      expect(webContents.send).not.toHaveBeenCalled();
+
+      // Simulate the load finishing
+      const callback = vi.mocked(webContents.once).mock.calls[0][1] as Function;
+      callback();
+
+      expect(webContents.send).toHaveBeenCalledWith('test-channel', { data: 'test' });
+    });
+
+    it('should handle invalid WebContents', () => {
+      expect(safelySendToWindow(null as any, 'test-channel', {})).toBe(false);
+    });
+  });
+
+  describe('setupDestroyListener', () => {
+    it('should set up a destroy listener', () => {
+      const webContents = mockWebContents();
+      const cleanup = vi.fn();
+
+      setupDestroyListener(webContents, cleanup);
+
+      expect(webContents.once).toHaveBeenCalledWith('destroyed', cleanup);
+    });
+  });
+
+  describe('WebContentsTracker', () => {
+    it('should track and retrieve active WebContents', () => {
+      const tracker = createWebContentsTracker();
+      const webContents1 = mockWebContents(1);
+      const webContents2 = mockWebContents(2);
+
+      tracker.track(webContents1);
+      tracker.track(webContents2);
+
+      expect(tracker.isTracked(webContents1)).toBe(true);
+      expect(tracker.isTracked(webContents2)).toBe(true);
+      expect(tracker.hasId(1)).toBe(true);
+      expect(tracker.hasId(2)).toBe(true);
+      expect(tracker.getActiveIds()).toEqual([1, 2]);
+      expect(tracker.getActiveWebContents()).toEqual([webContents1, webContents2]);
+    });
+
+    it('should ignore destroyed WebContents during tracking', () => {
+      const tracker = createWebContentsTracker();
+      const webContents = mockWebContents(1, true);
+
+      const result = tracker.track(webContents);
+
+      expect(result).toBe(false);
+      expect(tracker.isTracked(webContents)).toBe(false);
+      expect(tracker.hasId(1)).toBe(false);
+    });
+
+    it('should untrack WebContents correctly', () => {
+      const tracker = createWebContentsTracker();
+      const webContents1 = mockWebContents(1);
+      const webContents2 = mockWebContents(2);
+
+      tracker.track(webContents1);
+      tracker.track(webContents2);
+      tracker.untrack(webContents1);
+
+      expect(tracker.isTracked(webContents1)).toBe(false);
+      expect(tracker.isTracked(webContents2)).toBe(true);
+      expect(tracker.hasId(1)).toBe(false);
+      expect(tracker.hasId(2)).toBe(true);
+    });
+
+    it('should untrack by ID', () => {
+      const tracker = createWebContentsTracker();
+      const webContents1 = mockWebContents(1);
+      const webContents2 = mockWebContents(2);
+
+      tracker.track(webContents1);
+      tracker.track(webContents2);
+      tracker.untrackById(1);
+
+      expect(tracker.hasId(1)).toBe(false);
+      expect(tracker.hasId(2)).toBe(true);
+    });
+
+    it('should cleanup all tracked items', () => {
+      const tracker = createWebContentsTracker();
+      const webContents1 = mockWebContents(1);
+      const webContents2 = mockWebContents(2);
+
+      tracker.track(webContents1);
+      tracker.track(webContents2);
+      tracker.cleanup();
+
+      expect(tracker.getActiveIds()).toEqual([]);
+      expect(tracker.getActiveWebContents()).toEqual([]);
+    });
+
+    it('should remove destroyed WebContents from active list', () => {
+      const tracker = createWebContentsTracker();
+      const webContents1 = mockWebContents(1);
+      const webContents2 = mockWebContents(2);
+
+      tracker.track(webContents1);
+      tracker.track(webContents2);
+
+      // Now mark webContents1 as destroyed
+      vi.mocked(webContents1.isDestroyed).mockReturnValue(true);
+
+      // When we get active WebContents, it should filter out the destroyed one
+      expect(tracker.getActiveWebContents()).toEqual([webContents2]);
+    });
+  });
+
+  describe('prepareWebContents', () => {
+    it('should extract WebContents from wrappers', () => {
+      const webContents1 = mockWebContents(1);
+      const wrapper = mockWrapper(2);
+
+      const result = prepareWebContents([webContents1, wrapper]);
+
+      expect(result).toEqual([webContents1, wrapper.webContents]);
+    });
+
+    it('should filter out destroyed WebContents', () => {
+      const webContents1 = mockWebContents(1, true); // Destroyed
+      const wrapper = mockWrapper(2);
+
+      const result = prepareWebContents([webContents1, wrapper]);
+
+      expect(result).toEqual([wrapper.webContents]);
+    });
+
+    it('should handle invalid inputs', () => {
+      const result = prepareWebContents([null as any, undefined as any]);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -65,7 +65,8 @@ export interface BaseBridge<WindowId> {
 
 export interface WebContentsWrapper {
   webContents: WebContents;
-  isDestroyed(): boolean;
+  // WebContentsView has isDestroyed only on its webContents property
+  isDestroyed?: () => boolean;
 }
 
 // The object returned by mainZustandBridge

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 4.19.3
       turbo:
         specifier: ^2.4.1
-        version: 2.5.1
+        version: 2.5.2
 
   apps/electron-example:
     dependencies:
@@ -59,7 +59,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
-        version: 22.14.1
+        version: 22.15.2
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.2
@@ -68,7 +68,7 @@ importers:
         version: 19.1.2(@types/react@19.1.2)
       '@vitejs/plugin-react':
         specifier: ^4.4.0
-        version: 4.4.1(vite@6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1))
+        version: 4.4.1(vite@6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1))
       '@zubridge/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -83,13 +83,13 @@ importers:
         version: 26.0.12(electron-builder-squirrel-windows@26.0.12)
       electron-vite:
         specifier: ^3.0.0
-        version: 3.1.0(vite@6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1))
+        version: 3.1.0(vite@6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1))
       typescript:
         specifier: ^5.7.3
         version: 5.8.3
       vite:
         specifier: ^6.2.6
-        version: 6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1)
+        version: 6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)
       wdio-electron-service:
         specifier: ^8.0.1
         version: 8.1.0(electron@35.2.1)(webdriverio@9.12.7(puppeteer-core@22.15.0))
@@ -117,7 +117,7 @@ importers:
         version: 2.5.0
       '@types/node':
         specifier: ^22.14.0
-        version: 22.14.1
+        version: 22.15.2
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.2
@@ -126,7 +126,7 @@ importers:
         version: 19.1.2(@types/react@19.1.2)
       '@vitejs/plugin-react':
         specifier: ^4.4.0
-        version: 4.4.1(vite@6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1))
+        version: 4.4.1(vite@6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1))
       '@zubridge/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -138,7 +138,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.2.6
-        version: 6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1)
+        version: 6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)
 
   apps/tauri-v1-example:
     dependencies:
@@ -163,7 +163,7 @@ importers:
         version: 1.6.3
       '@types/node':
         specifier: ^22.14.0
-        version: 22.14.1
+        version: 22.15.2
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.2
@@ -172,7 +172,7 @@ importers:
         version: 19.1.2(@types/react@19.1.2)
       '@vitejs/plugin-react':
         specifier: ^4.4.0
-        version: 4.4.1(vite@6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1))
+        version: 4.4.1(vite@6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1))
       '@zubridge/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -184,7 +184,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.2.6
-        version: 6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1)
+        version: 6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)
 
   e2e:
     dependencies:
@@ -203,7 +203,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^22.14.0
-        version: 22.14.1
+        version: 22.15.2
       '@wdio/cli':
         specifier: ^9.12.4
         version: 9.12.7(puppeteer-core@22.15.0)
@@ -252,13 +252,13 @@ importers:
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/node':
         specifier: ^22.14.0
-        version: 22.14.1
+        version: 22.15.2
       '@types/shelljs':
         specifier: ^0.8.15
         version: 0.8.15
       '@vitest/coverage-v8':
         specifier: ^3.0.5
-        version: 3.1.2(vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.14.1)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1))
+        version: 3.1.2(vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1))
       jsdom:
         specifier: ^26.0.0
         version: 26.1.0
@@ -285,7 +285,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.0.5
-        version: 3.1.2(@types/debug@4.1.12)(@types/node@22.14.1)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1)
+        version: 3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/tauri:
     dependencies:
@@ -313,7 +313,7 @@ importers:
         version: 0.8.15
       '@vitest/coverage-v8':
         specifier: ^3.0.9
-        version: 3.1.2(vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.14.1)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1))
+        version: 3.1.2(vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1))
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -331,7 +331,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.0.9
-        version: 3.1.2(@types/debug@4.1.12)(@types/node@22.14.1)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1)
+        version: 3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/tauri-plugin-zubridge:
     dependencies:
@@ -1289,11 +1289,11 @@ packages:
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
 
-  '@types/node@20.17.30':
-    resolution: {integrity: sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==}
+  '@types/node@20.17.31':
+    resolution: {integrity: sha512-quODOCNXQAbNf1Q7V+fI8WyErOCh0D5Yd31vHnKu4GkSztGQ7rlltAaqXhHhLl33tlVyUXs2386MkANSwgDn6A==}
 
-  '@types/node@22.14.1':
-    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
+  '@types/node@22.15.2':
+    resolution: {integrity: sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -1603,8 +1603,8 @@ packages:
   bare-events@2.5.4:
     resolution: {integrity: sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==}
 
-  bare-fs@4.1.2:
-    resolution: {integrity: sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==}
+  bare-fs@4.1.3:
+    resolution: {integrity: sha512-OeEZYIg+2qepaWLyphaOXHAHKo3xkM8y3BeGAvHdMN8GNWvEAU1Yw6rYpGzu/wDDbKxgEjVeVDpgGhDzaeMpjg==}
     engines: {bare: '>=1.16.0'}
     peerDependencies:
       bare-buffer: '*'
@@ -2126,8 +2126,8 @@ packages:
   electron-publish@26.0.11:
     resolution: {integrity: sha512-a8QRH0rAPIWH9WyyS5LbNvW9Ark6qe63/LqDB7vu2JXYpi0Gma5Q60Dh4tmTqhOBQt0xsrzD8qE7C+D7j+B24A==}
 
-  electron-to-chromium@1.5.141:
-    resolution: {integrity: sha512-qS+qH9oqVYc1ooubTiB9l904WVyM6qNYxtOEEGReoZXw3xlqeYdFr5GclNzbkAufWgwWLEPoDi3d9MoRwwIjGw==}
+  electron-to-chromium@1.5.142:
+    resolution: {integrity: sha512-Ah2HgkTu/9RhTDNThBtzu2Wirdy4DC9b0sMT1pUhbkZQ5U/iwmE+PHZX1MpjD5IkJCc2wSghgGG/B04szAx07w==}
 
   electron-vite@3.1.0:
     resolution: {integrity: sha512-M7aAzaRvSl5VO+6KN4neJCYLHLpF/iWo5ztchI/+wMxIieDZQqpbCYfaEHHHPH6eupEzfvZdLYdPdmvGqoVe0Q==}
@@ -3843,8 +3843,8 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  smol-toml@1.3.3:
-    resolution: {integrity: sha512-KMVLNWu490KlNfD0lbfDBUktJIEaZRBj1eeK0SMfdpO/rfyARIzlnPVI1Ge4l0vtSJmQUAiGKxMyLGrCT38iyA==}
+  smol-toml@1.3.4:
+    resolution: {integrity: sha512-UOPtVuYkzYGee0Bd2Szz8d2G3RfMfJ2t3qVdZUAozZyAk+a0Sxa+QKix0YCwjL/A1RR0ar44nCxaoN9FxdJGwA==}
     engines: {node: '>= 18'}
 
   socks-proxy-agent@7.0.0:
@@ -4114,38 +4114,38 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo-darwin-64@2.5.1:
-    resolution: {integrity: sha512-U9lT1rZ20PQjEYDiNE0aZrU6K+StAE8rood9xn3pV1w+CSby56HkdR2AffzMdFf8iPTeZfcY1qL62rDcCeRPTw==}
+  turbo-darwin-64@2.5.2:
+    resolution: {integrity: sha512-2aIl0Sx230nLk+Cg2qSVxvPOBWCZpwKNuAMKoROTvWKif6VMpkWWiR9XEPoz7sHeLmCOed4GYGMjL1bqAiIS/g==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.5.1:
-    resolution: {integrity: sha512-1Mp0LeP9JENqHnurGNyD557sndPt2BYUbgzUX87tYIdu/26dHyqlobiRzPpEfkOGB/sV4exhJUJGXB1h72szLQ==}
+  turbo-darwin-arm64@2.5.2:
+    resolution: {integrity: sha512-MrFYhK/jYu8N6QlqZtqSHi3e4QVxlzqU3ANHTKn3/tThuwTLbNHEvzBPWSj5W7nZcM58dCqi6gYrfRz6bJZyAA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.5.1:
-    resolution: {integrity: sha512-Cl2yKumJQAlNG5UA7vjCU6SPBLrcKaGhOjTaUjGHeD9WLL8vh4FwOlhOD2wk7zCUlhpJaM73WHY+oOZGMqmzOg==}
+  turbo-linux-64@2.5.2:
+    resolution: {integrity: sha512-LxNqUE2HmAJQ/8deoLgMUDzKxd5bKxqH0UBogWa+DF+JcXhtze3UTMr6lEr0dEofdsEUYK1zg8FRjglmwlN5YA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.5.1:
-    resolution: {integrity: sha512-OFpb/9YZJG8v3nttD4K5dxW3bwsZp++oxAykpYsPhp552EX6r+dJrt2dzX3C0azls2JLf/UzTpA83fRoM8mC4g==}
+  turbo-linux-arm64@2.5.2:
+    resolution: {integrity: sha512-0MI1Ao1q8zhd+UUbIEsrM+yLq1BsrcJQRGZkxIsHFlGp7WQQH1oR3laBgfnUCNdCotCMD6w4moc9pUbXdOR3bg==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.5.1:
-    resolution: {integrity: sha512-6XnfSxE8xPETVAlAwfMqCuVuZbq9gXTj8H/Eggv/i3Tjoh2l5xMVTOmg3/zV4RlDtTcwhnvXgXx8LEXrSRZmQQ==}
+  turbo-windows-64@2.5.2:
+    resolution: {integrity: sha512-hOLcbgZzE5ttACHHyc1ajmWYq4zKT42IC3G6XqgiXxMbS+4eyVYTL+7UvCZBd3Kca1u4TLQdLQjeO76zyDJc2A==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.5.1:
-    resolution: {integrity: sha512-Nc9abxTCpRL8ejzzIm5j6jze3jFi23ZtU83Fwz2N9StquYHGEi72isyeCkrhzCiUvZZEPlFyFaXOSShcJUK58Q==}
+  turbo-windows-arm64@2.5.2:
+    resolution: {integrity: sha512-fMU41ABhSLa18H8V3Z7BMCGynQ8x+wj9WyBMvWm1jeyRKgkvUYJsO2vkIsy8m0vrwnIeVXKOIn6eSe1ddlBVqw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.5.1:
-    resolution: {integrity: sha512-LT0wYyT+HY4StvmGMq1k2tHCIwauaWSXwyP+tCUked9vja5xEisW8b8NIJGi9BWH5HYH9Og1DysaQFTf8BiydQ==}
+  turbo@2.5.2:
+    resolution: {integrity: sha512-Qo5lfuStr6LQh3sPQl7kIi243bGU4aHGDQJUf6ylAdGwks30jJFloc9NYHP7Y373+gGU9OS0faA4Mb5Sy8X9Xw==}
     hasBin: true
 
   type-fest@0.13.1:
@@ -4963,7 +4963,7 @@ snapshots:
       '@inquirer/figures': 1.0.11
       '@inquirer/type': 2.0.0
       '@types/mute-stream': 0.0.4
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
@@ -5065,7 +5065,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -5432,7 +5432,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
       '@types/responselike': 1.0.3
 
   '@types/debug@4.1.12':
@@ -5443,12 +5443,12 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
 
   '@types/http-cache-semantics@4.0.4': {}
 
@@ -5464,7 +5464,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
 
   '@types/minimatch@5.1.2': {}
 
@@ -5474,13 +5474,13 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
 
-  '@types/node@20.17.30':
+  '@types/node@20.17.31':
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@22.14.1':
+  '@types/node@22.15.2':
     dependencies:
       undici-types: 6.21.0
 
@@ -5488,7 +5488,7 @@ snapshots:
 
   '@types/plist@3.0.5':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
       xmlbuilder: 15.1.1
     optional: true
 
@@ -5502,14 +5502,14 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
 
   '@types/semver@7.7.0': {}
 
   '@types/shelljs@0.8.15':
     dependencies:
       '@types/glob': 7.2.0
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
 
   '@types/sinonjs__fake-timers@8.1.5': {}
 
@@ -5524,7 +5524,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -5534,21 +5534,21 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
     optional: true
 
-  '@vitejs/plugin-react@4.4.1(vite@6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1))':
+  '@vitejs/plugin-react@4.4.1(vite@6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1)
+      vite: 6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.1.2(vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.14.1)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1))':
+  '@vitest/coverage-v8@3.1.2(vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -5562,7 +5562,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.14.1)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1)
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5573,13 +5573,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.2(vite@6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1))':
+  '@vitest/mocker@3.1.2(vite@6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 3.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1)
+      vite: 6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -5618,7 +5618,7 @@ snapshots:
 
   '@wdio/cli@9.12.7(puppeteer-core@22.15.0)':
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.17.31
       '@vitest/snapshot': 2.1.9
       '@wdio/config': 9.12.6
       '@wdio/globals': 9.12.7(@wdio/logger@9.4.4)(puppeteer-core@22.15.0)
@@ -5679,7 +5679,7 @@ snapshots:
       find-versions: 6.0.0
       json5: 2.2.3
       read-package-up: 11.0.0
-      smol-toml: 1.3.3
+      smol-toml: 1.3.4
       tsx: 4.19.3
       yaml: 2.7.1
     transitivePeerDependencies:
@@ -5699,7 +5699,7 @@ snapshots:
 
   '@wdio/local-runner@9.12.7(puppeteer-core@22.15.0)':
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.17.31
       '@wdio/logger': 9.4.4
       '@wdio/repl': 9.4.4
       '@wdio/runner': 9.12.7(puppeteer-core@22.15.0)
@@ -5724,7 +5724,7 @@ snapshots:
   '@wdio/mocha-framework@9.12.6':
     dependencies:
       '@types/mocha': 10.0.10
-      '@types/node': 20.17.30
+      '@types/node': 20.17.31
       '@wdio/logger': 9.4.4
       '@wdio/types': 9.12.6
       '@wdio/utils': 9.12.6
@@ -5737,11 +5737,11 @@ snapshots:
 
   '@wdio/repl@9.4.4':
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.17.31
 
   '@wdio/reporter@9.12.6':
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.17.31
       '@wdio/logger': 9.4.4
       '@wdio/types': 9.12.6
       diff: 7.0.0
@@ -5749,7 +5749,7 @@ snapshots:
 
   '@wdio/runner@9.12.7(puppeteer-core@22.15.0)':
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.17.31
       '@wdio/config': 9.12.6
       '@wdio/dot-reporter': 9.12.6
       '@wdio/globals': 9.12.7(@wdio/logger@9.4.4)(puppeteer-core@22.15.0)
@@ -5769,7 +5769,7 @@ snapshots:
 
   '@wdio/types@9.12.6':
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.17.31
 
   '@wdio/utils@9.12.6':
     dependencies:
@@ -5957,7 +5957,7 @@ snapshots:
   bare-events@2.5.4:
     optional: true
 
-  bare-fs@4.1.2:
+  bare-fs@4.1.3:
     dependencies:
       bare-events: 2.5.4
       bare-path: 3.0.0
@@ -6016,7 +6016,7 @@ snapshots:
   browserslist@4.24.4:
     dependencies:
       caniuse-lite: 1.0.30001715
-      electron-to-chromium: 1.5.141
+      electron-to-chromium: 1.5.142
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.4)
 
@@ -6567,9 +6567,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-to-chromium@1.5.141: {}
+  electron-to-chromium@1.5.142: {}
 
-  electron-vite@3.1.0(vite@6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1)):
+  electron-vite@3.1.0(vite@6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-arrow-functions': 7.25.9(@babel/core@7.26.10)
@@ -6577,7 +6577,7 @@ snapshots:
       esbuild: 0.25.3
       magic-string: 0.30.17
       picocolors: 1.1.1
-      vite: 6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1)
+      vite: 6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6596,7 +6596,7 @@ snapshots:
   electron@35.2.1:
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -7380,7 +7380,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -8409,7 +8409,7 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  smol-toml@1.3.3: {}
+  smol-toml@1.3.4: {}
 
   socks-proxy-agent@7.0.0:
     dependencies:
@@ -8568,7 +8568,7 @@ snapshots:
       pump: 3.0.2
       tar-stream: 3.1.7
     optionalDependencies:
-      bare-fs: 4.1.2
+      bare-fs: 4.1.3
       bare-path: 3.0.0
     transitivePeerDependencies:
       - bare-buffer
@@ -8688,32 +8688,32 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo-darwin-64@2.5.1:
+  turbo-darwin-64@2.5.2:
     optional: true
 
-  turbo-darwin-arm64@2.5.1:
+  turbo-darwin-arm64@2.5.2:
     optional: true
 
-  turbo-linux-64@2.5.1:
+  turbo-linux-64@2.5.2:
     optional: true
 
-  turbo-linux-arm64@2.5.1:
+  turbo-linux-arm64@2.5.2:
     optional: true
 
-  turbo-windows-64@2.5.1:
+  turbo-windows-64@2.5.2:
     optional: true
 
-  turbo-windows-arm64@2.5.1:
+  turbo-windows-arm64@2.5.2:
     optional: true
 
-  turbo@2.5.1:
+  turbo@2.5.2:
     optionalDependencies:
-      turbo-darwin-64: 2.5.1
-      turbo-darwin-arm64: 2.5.1
-      turbo-linux-64: 2.5.1
-      turbo-linux-arm64: 2.5.1
-      turbo-windows-64: 2.5.1
-      turbo-windows-arm64: 2.5.1
+      turbo-darwin-64: 2.5.2
+      turbo-darwin-arm64: 2.5.2
+      turbo-linux-64: 2.5.2
+      turbo-linux-arm64: 2.5.2
+      turbo-windows-64: 2.5.2
+      turbo-windows-arm64: 2.5.2
 
   type-fest@0.13.1:
     optional: true
@@ -8787,13 +8787,13 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite-node@3.1.2(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1):
+  vite-node@3.1.2(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1)
+      vite: 6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8808,7 +8808,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1):
+  vite@6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.3
       fdir: 6.4.4(picomatch@4.0.2)
@@ -8817,15 +8817,15 @@ snapshots:
       rollup: 4.40.0
       tinyglobby: 0.2.13
     optionalDependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
       fsevents: 2.3.3
       tsx: 4.19.3
       yaml: 2.7.1
 
-  vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.14.1)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1):
+  vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(jsdom@26.1.0)(tsx@4.19.3)(yaml@2.7.1):
     dependencies:
       '@vitest/expect': 3.1.2
-      '@vitest/mocker': 3.1.2(vite@6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1))
+      '@vitest/mocker': 3.1.2(vite@6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1))
       '@vitest/pretty-format': 3.1.2
       '@vitest/runner': 3.1.2
       '@vitest/snapshot': 3.1.2
@@ -8842,12 +8842,12 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.3(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1)
-      vite-node: 3.1.2(@types/node@22.14.1)(tsx@4.19.3)(yaml@2.7.1)
+      vite: 6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)
+      vite-node: 3.1.2(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
@@ -8888,7 +8888,7 @@ snapshots:
       '@wdio/logger': 9.4.4
       compare-versions: 6.1.1
       debug: 4.4.0(supports-color@8.1.1)
-      electron-to-chromium: 1.5.141
+      electron-to-chromium: 1.5.142
       fast-copy: 3.0.2
       puppeteer-core: 22.15.0
       read-package-up: 11.0.0
@@ -8906,7 +8906,7 @@ snapshots:
 
   webdriver@9.12.6:
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.17.31
       '@types/ws': 8.18.1
       '@wdio/config': 9.12.6
       '@wdio/logger': 9.4.4
@@ -8924,7 +8924,7 @@ snapshots:
 
   webdriverio@9.12.7(puppeteer-core@22.15.0):
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.17.31
       '@types/sinonjs__fake-timers': 8.1.5
       '@wdio/config': 9.12.6
       '@wdio/logger': 9.4.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2126,8 +2126,8 @@ packages:
   electron-publish@26.0.11:
     resolution: {integrity: sha512-a8QRH0rAPIWH9WyyS5LbNvW9Ark6qe63/LqDB7vu2JXYpi0Gma5Q60Dh4tmTqhOBQt0xsrzD8qE7C+D7j+B24A==}
 
-  electron-to-chromium@1.5.142:
-    resolution: {integrity: sha512-Ah2HgkTu/9RhTDNThBtzu2Wirdy4DC9b0sMT1pUhbkZQ5U/iwmE+PHZX1MpjD5IkJCc2wSghgGG/B04szAx07w==}
+  electron-to-chromium@1.5.143:
+    resolution: {integrity: sha512-QqklJMOFBMqe46k8iIOwA9l2hz57V2OKMmP5eSWcUvwx+mASAsbU+wkF1pHjn9ZVSBPrsYWr4/W/95y5SwYg2g==}
 
   electron-vite@3.1.0:
     resolution: {integrity: sha512-M7aAzaRvSl5VO+6KN4neJCYLHLpF/iWo5ztchI/+wMxIieDZQqpbCYfaEHHHPH6eupEzfvZdLYdPdmvGqoVe0Q==}
@@ -6016,7 +6016,7 @@ snapshots:
   browserslist@4.24.4:
     dependencies:
       caniuse-lite: 1.0.30001715
-      electron-to-chromium: 1.5.142
+      electron-to-chromium: 1.5.143
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.4)
 
@@ -6567,7 +6567,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-to-chromium@1.5.142: {}
+  electron-to-chromium@1.5.143: {}
 
   electron-vite@3.1.0(vite@6.3.3(@types/node@22.15.2)(tsx@4.19.3)(yaml@2.7.1)):
     dependencies:
@@ -8888,7 +8888,7 @@ snapshots:
       '@wdio/logger': 9.4.4
       compare-versions: 6.1.1
       debug: 4.4.0(supports-color@8.1.1)
-      electron-to-chromium: 1.5.142
+      electron-to-chromium: 1.5.143
       fast-copy: 3.0.2
       puppeteer-core: 22.15.0
       read-package-up: 11.0.0


### PR DESCRIPTION
Closes #73, #77.

- Ensure explicit support for BrowserView, WebContentsView and direct WebContents.
- Updating the example app to use four windows in order to test the above.
- We encountered issues getting the BrowserView and WebContentsView windows to work with WDIO (#78)
  - worked around by only initialising these windows when not running the E2Es	
- Added case-insensitive handler matching
- Parity between Tauri and Electron example apps

