### PR TITLE
fix(ci): grant pull-requests: write to release-auto and release-manual callers

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -47,8 +47,8 @@ on:
         required: false
 
 # pull-requests: write is needed by the standing-pr publish path (manifest comment read +
-# completion comment). Called workflows can only downgrade caller permissions, so it must
-# be declared here too — callers that don't grant it (release-auto/manual) cap it to none.
+# completion comment). All callers must explicitly grant it — GitHub validates the caller's
+# permission block against what the reusable workflow declares and errors if any are missing.
 permissions:
   id-token: write
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     with:
       target_branch: main
       bump: ${{ needs.gate.outputs.bump }}
@@ -157,6 +158,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     with:
       target_branch: ${{ inputs.target_branch }}
       bump: ${{ inputs.bump }}


### PR DESCRIPTION
## Problem

GitHub validates that every permission declared at the workflow level in a reusable workflow is explicitly granted by the caller. `_release.reusable.yml` declares `pull-requests: write` (needed by the standing-PR publish path to read the manifest comment and post a completion comment), but `release-auto` and `release-manual` in `release.yml` were not granting it.

This produced a workflow annotation on every PR:

```
Error calling workflow '_release.reusable.yml'. The workflow is requesting
'pull-requests: write', but is only allowed 'pull-requests: none'.
```

## Fix

- Add `pull-requests: write` to the `permissions` block of `release-auto` and `release-manual`.
- Correct the misleading comment in `_release.reusable.yml` which incorrectly stated that callers without the grant would silently cap to `none` — GitHub errors instead.

`release-standing-pr` already had `pull-requests: write` and was unaffected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a CI permission error where `release-auto` and `release-manual` caller jobs were missing the `pull-requests: write` grant required by `_release.reusable.yml`, causing GitHub to reject the workflow call with a hard error rather than silently downgrading. The comment in the reusable workflow is also corrected to accurately describe this behavior.

- Adds `pull-requests: write` to the `permissions` block of both `release-auto` and `release-manual` in `release.yml`; `release-standing-pr` already carried this grant and is unchanged.
- Updates the explanatory comment in `_release.reusable.yml` to replace the incorrect "callers without the grant cap to none" phrasing with the accurate "GitHub validates and errors if any declared permission is missing" description.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds two missing permission grants that were causing workflow call failures on every PR.

Both changes are minimal and precise: two one-line permission additions and a comment correction. The permission model is consistent across all three caller jobs after this fix, and the reusable workflow's job-level permissions already declare `pull-requests: write`, so there is no over-granting concern.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds `pull-requests: write` to `release-auto` and `release-manual` job permission blocks so they satisfy the reusable workflow's declared permissions |
| .github/workflows/_release.reusable.yml | Corrects the comment above the `permissions` block to accurately describe GitHub's behavior (hard error on missing grant, not silent downgrade) |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant RA as release-auto
    participant RM as release-manual
    participant RSP as release-standing-pr
    participant RR as _release.reusable.yml

    Note over RA,RR: Before fix: pull-requests: write missing on RA and RM
    RA->>RR: call (contents:write, id-token:write) ❌
    RR-->>RA: Error: pull-requests:write not granted

    RM->>RR: call (contents:write, id-token:write) ❌
    RR-->>RM: Error: pull-requests:write not granted

    RSP->>RR: call (contents:write, id-token:write, pull-requests:write) ✅
    RR-->>RSP: OK

    Note over RA,RR: After fix: all callers grant pull-requests: write
    RA->>RR: call (contents:write, id-token:write, pull-requests:write) ✅
    RR-->>RA: OK

    RM->>RR: call (contents:write, id-token:write, pull-requests:write) ✅
    RR-->>RM: OK

    RSP->>RR: call (contents:write, id-token:write, pull-requests:write) ✅
    RR-->>RSP: OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant RA as release-auto
    participant RM as release-manual
    participant RSP as release-standing-pr
    participant RR as _release.reusable.yml

    Note over RA,RR: Before fix: pull-requests: write missing on RA and RM
    RA->>RR: call (contents:write, id-token:write) ❌
    RR-->>RA: Error: pull-requests:write not granted

    RM->>RR: call (contents:write, id-token:write) ❌
    RR-->>RM: Error: pull-requests:write not granted

    RSP->>RR: call (contents:write, id-token:write, pull-requests:write) ✅
    RR-->>RSP: OK

    Note over RA,RR: After fix: all callers grant pull-requests: write
    RA->>RR: call (contents:write, id-token:write, pull-requests:write) ✅
    RR-->>RA: OK

    RM->>RR: call (contents:write, id-token:write, pull-requests:write) ✅
    RR-->>RM: OK

    RSP->>RR: call (contents:write, id-token:write, pull-requests:write) ✅
    RR-->>RSP: OK
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): grant pull-requests: write to r..."](https://github.com/goosewobbler/zubridge/commit/497cf4e03e60158302871dd4287bbc9d93457a72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37994995)</sub>

<!-- /greptile_comment -->