### PR TITLE
chore(releasekit): bump to v0.30.1

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Run ReleaseKit
         id: releasekit
         if: ${{ inputs.standing_pr_number == '' }}
-        uses: goosewobbler/releasekit@v0.29.1
+        uses: goosewobbler/releasekit@v0.30.1
         with:
           mode: release
           node-version: '24'
@@ -250,7 +250,7 @@ jobs:
       - name: Run ReleaseKit (standing PR publish)
         id: releasekit-standing
         if: ${{ inputs.standing_pr_number != '' }}
-        uses: goosewobbler/releasekit@v0.29.1
+        uses: goosewobbler/releasekit@v0.30.1
         with:
           mode: standing-pr-publish
           node-version: '24'

--- a/.github/workflows/_standing-pr-update.reusable.yml
+++ b/.github/workflows/_standing-pr-update.reusable.yml
@@ -43,7 +43,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Update standing release PR
-        uses: goosewobbler/releasekit@v0.29.1
+        uses: goosewobbler/releasekit@v0.30.1
         with:
           mode: standing-pr-update
           node-version: '24'

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Release Preview
-        uses: goosewobbler/releasekit@v0.29.1
+        uses: goosewobbler/releasekit@v0.30.1
         with:
           node-version: '24'
           mode: preview

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Run ReleaseKit Gate
         id: gate
-        uses: goosewobbler/releasekit@v0.29.1
+        uses: goosewobbler/releasekit@v0.30.1
         with:
           mode: gate
           node-version: '24'

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
-    "@releasekit/release": "^0.29.1",
+    "@releasekit/release": "^0.30.1",
     "@types/shelljs": "^0.10.0",
     "@wdio/logger": "^9.4.4",
     "cross-env": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       '@releasekit/release':
-        specifier: ^0.29.1
-        version: 0.29.1(conventional-commits-parser@6.4.0)(ws@8.21.0)
+        specifier: ^0.30.1
+        version: 0.30.1(conventional-commits-parser@6.4.0)(ws@8.21.0)
       '@types/shelljs':
         specifier: ^0.10.0
         version: 0.10.0
@@ -2432,23 +2432,23 @@ packages:
       react-redux:
         optional: true
 
-  '@releasekit/notes@0.29.1':
-    resolution: {integrity: sha512-LOc9yD7YQnhdBN1NsovtR/iYix3+wWdhsjWERDnBAQM5FFYPo/5jzXtqk495FL2n8k3pXJXP2SV6qdoo4Z9UHg==}
+  '@releasekit/notes@0.30.1':
+    resolution: {integrity: sha512-JVrUNRIWjSrhRyF5pkYEOlGoZ151pUB+rknNtNA0G8GyXmmhBWj1Soi6qiHkUd/AOOSbGijMvtMeHTFAIFdqfw==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/publish@0.29.1':
-    resolution: {integrity: sha512-HJFbY+Zc2XQyXflTzlNyJoANWxP8BB1S4yvqUMr9QG0PfrsjsSRidICGwzWKPHoYHLslSaDdZMMBUpPNIoiN1Q==}
+  '@releasekit/publish@0.30.1':
+    resolution: {integrity: sha512-cBY0hJvcjIyuLueaFlbhyVdSC4nUZ5iqcOWL+6mh0mk5JiyIbPuO7xp/hm7O/p9w/XOdDJdL0ZRKkMCXgNmFBQ==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/release@0.29.1':
-    resolution: {integrity: sha512-wqRpt9YGBb2NXLRBHS+X6Tcr7afml6B5sh177Y+r+sWfmv81wqZWduViqp11i0u/gWdAdqr/EMDd4WjHbnmEbg==}
+  '@releasekit/release@0.30.1':
+    resolution: {integrity: sha512-IDz19iMuXVxqYP2RHZ3ntGhBDlEM95KYStN0b8nwhMZH8TOCaSm9R6i0Nvz7rWKmkJpgUvIZh68uVzNKddteRA==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/version@0.29.1':
-    resolution: {integrity: sha512-RcpJkVR5nAKCqr46xy49U73VNZ/KP8LFfe9xvbZIoXsWhivzACwGxBSYjXO4bY04tYBRbxxsRszVYyhwNfOQ4Q==}
+  '@releasekit/version@0.30.1':
+    resolution: {integrity: sha512-GFhGWw6+Hk8wRq7FoLrSjwtatTBletVtiq9R//3hWxdn++5JGSQdIf+Pzp7fUH68h2y9t53lurh3Z2ci+IW6+w==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3705,9 +3705,6 @@ packages:
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
-
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
@@ -7875,7 +7872,7 @@ snapshots:
     optionalDependencies:
       react: 19.2.7
 
-  '@releasekit/notes@0.29.1(ws@8.21.0)':
+  '@releasekit/notes@0.30.1(ws@8.21.0)':
     dependencies:
       '@anthropic-ai/sdk': 0.104.2(zod@4.4.3)
       '@octokit/request-error': 7.1.0
@@ -7894,7 +7891,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  '@releasekit/publish@0.29.1':
+  '@releasekit/publish@0.30.1':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
@@ -7905,13 +7902,13 @@ snapshots:
       yaml: 2.9.0
       zod: 4.4.3
 
-  '@releasekit/release@0.29.1(conventional-commits-parser@6.4.0)(ws@8.21.0)':
+  '@releasekit/release@0.30.1(conventional-commits-parser@6.4.0)(ws@8.21.0)':
     dependencies:
       '@manypkg/get-packages': 3.1.0
       '@octokit/rest': 22.0.1
-      '@releasekit/notes': 0.29.1(ws@8.21.0)
-      '@releasekit/publish': 0.29.1
-      '@releasekit/version': 0.29.1(conventional-commits-parser@6.4.0)
+      '@releasekit/notes': 0.30.1(ws@8.21.0)
+      '@releasekit/publish': 0.30.1
+      '@releasekit/version': 0.30.1(conventional-commits-parser@6.4.0)
       chalk: 5.6.2
       commander: 14.0.3
       conventional-changelog-angular: 8.3.1
@@ -7926,7 +7923,7 @@ snapshots:
       - conventional-commits-parser
       - ws
 
-  '@releasekit/version@0.29.1(conventional-commits-parser@6.4.0)':
+  '@releasekit/version@0.30.1(conventional-commits-parser@6.4.0)':
     dependencies:
       '@manypkg/get-packages': 3.1.0
       '@types/minimatch': 5.1.2
@@ -9178,10 +9175,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@2.1.0:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@2.1.1:
     dependencies:
@@ -10672,7 +10665,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
@@ -10938,7 +10931,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.1
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

Bumps releasekit to **v0.30.1** across the `@releasekit/release` devDependency and all five workflow action refs, via `scripts/update-releasekit.ts`.

## Why

0.30.x directly ships the fixes for the two issues that surfaced during the first standing-PR run:

- **[goosewobbler/releasekit#333](https://github.com/goosewobbler/releasekit/issues/333)** — oversized standing-PR bodies are now truncated to prevent the 65536-char GitHub API 422.
- **[goosewobbler/releasekit#334](https://github.com/goosewobbler/releasekit/issues/334)** — warns when baseline tags are missing.
- Version bumping now falls back to full changelog history when no baseline tag exists.

0.30.1 is a follow-up patch on that line. The manual baseline tags created for the first run remain valid and still scope the changelog; this upgrade just removes the footgun for future first-time packages.

## Changes

- `package.json`: `@releasekit/release` → `^0.30.1`
- `pnpm-lock.yaml`: re-resolved (releasekit subpackages only)
- Action refs `goosewobbler/releasekit@v…` → `@v0.30.1` in:
  - `.github/workflows/release.yml`
  - `.github/workflows/_release.reusable.yml` (2 occurrences)
  - `.github/workflows/_standing-pr-update.reusable.yml`
  - `.github/workflows/release-preview.yml`

No config schema changes required — all 0.30.x changes are additive fixes/features.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Bumps all releasekit references from `v0.29.1` to `v0.30.1` (note: the PR description says v0.30.0, but the actual changes target v0.30.1) to pick up fixes for oversized standing-PR bodies and missing baseline-tag warnings.

- All five workflow action refs (`goosewobbler/releasekit@v0.29.1` → `@v0.30.1`) across four workflow files are updated consistently.
- `@releasekit/release` in `package.json` and all four `@releasekit/*` subpackages in `pnpm-lock.yaml` are re-resolved to `0.30.1`; incidental transitive bumps include `brace-expansion` `2.1.0` → `2.1.1` and `@babel/runtime` `7.29.2` → `7.29.7`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all releasekit refs are updated consistently across every workflow file and the lockfile, with no config schema changes needed.

This is a mechanical version bump across six files. All action refs and the npm dependency land on the same target version (v0.30.1), the lockfile re-resolution is consistent, and the upstream release is described as additive fixes only.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/_release.reusable.yml | Both releasekit action refs updated from v0.29.1 to v0.30.1 consistently |
| .github/workflows/_standing-pr-update.reusable.yml | Action ref updated from v0.29.1 to v0.30.1 |
| .github/workflows/release-preview.yml | Action ref updated from v0.29.1 to v0.30.1 |
| .github/workflows/release.yml | Action ref updated from v0.29.1 to v0.30.1 |
| package.json | @releasekit/release devDependency bumped from ^0.29.1 to ^0.30.1 |
| pnpm-lock.yaml | All four @releasekit/* subpackages re-resolved to 0.30.1; incidental transitive bumps: brace-expansion 2.1.0→2.1.1 and @babel/runtime 7.29.2→7.29.7 |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["scripts/update-releasekit.ts"] -->|bumps refs| B["package.json\n@releasekit/release ^0.29.1 → ^0.30.1"]
    A -->|bumps refs| C["pnpm-lock.yaml\n0.29.1 → 0.30.1 snapshots"]
    A -->|bumps action ref| D["release.yml\ngoosewobbler/releasekit@v0.30.1"]
    A -->|bumps action ref x2| E["_release.reusable.yml\ngoosewobbler/releasekit@v0.30.1"]
    A -->|bumps action ref| F["_standing-pr-update.reusable.yml\ngoosewobbler/releasekit@v0.30.1"]
    A -->|bumps action ref| G["release-preview.yml\ngoosewobbler/releasekit@v0.30.1"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["scripts/update-releasekit.ts"] -->|bumps refs| B["package.json\n@releasekit/release ^0.29.1 → ^0.30.1"]
    A -->|bumps refs| C["pnpm-lock.yaml\n0.29.1 → 0.30.1 snapshots"]
    A -->|bumps action ref| D["release.yml\ngoosewobbler/releasekit@v0.30.1"]
    A -->|bumps action ref x2| E["_release.reusable.yml\ngoosewobbler/releasekit@v0.30.1"]
    A -->|bumps action ref| F["_standing-pr-update.reusable.yml\ngoosewobbler/releasekit@v0.30.1"]
    A -->|bumps action ref| G["release-preview.yml\ngoosewobbler/releasekit@v0.30.1"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["chore(releasekit): bump to v0.30.1"](https://github.com/goosewobbler/zubridge/commit/43b64710d29e3565efa9771ee2a784ba1c24199f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38036800)</sub>

<!-- /greptile_comment -->