### PR TITLE
test(perf): bound bench dispatch concurrency + capture v3.0 baseline

### DIFF
--- a/benches/baseline.json
+++ b/benches/baseline.json
@@ -1,0 +1,108 @@
+{
+  "capturedAt": "2026-06-25T10:38:21.887Z",
+  "platform": "darwin",
+  "node": "v24.14.0",
+  "electron": "42.4.0",
+  "zubridgeElectron": "3.0.0",
+  "modes": {
+    "custom": {
+      "capturedAt": "2026-06-25T10:37:30.252Z",
+      "platform": "darwin",
+      "dispatchRoundTrip": {
+        "samples": 500,
+        "mean": 18.028,
+        "p50": 18,
+        "p95": 19,
+        "p99": 19.2,
+        "min": 16.8,
+        "max": 21.7
+      },
+      "throughput": {
+        "actions": 50000,
+        "elapsedMs": 4560.3,
+        "actionsPerSec": 10964
+      },
+      "multiWindowPropagation": {
+        "samples": 100,
+        "mean": 17.21,
+        "p50": 17,
+        "p95": 18,
+        "p99": 19,
+        "min": 16,
+        "max": 19
+      },
+      "memory": {
+        "heapBeforeBytes": 25287952,
+        "heapAfterBytes": 23214524,
+        "heapDeltaBytes": -2073428,
+        "note": "Electron main-process Node heap only; native allocations not measured. Becomes more important at 3.2 when the Rust core lands — track delta direction, not absolute size."
+      }
+    },
+    "redux": {
+      "capturedAt": "2026-06-25T10:36:33.658Z",
+      "platform": "darwin",
+      "dispatchRoundTrip": {
+        "samples": 500,
+        "mean": 17.977,
+        "p50": 17.9,
+        "p95": 19,
+        "p99": 19.5,
+        "min": 16.6,
+        "max": 20.7
+      },
+      "throughput": {
+        "actions": 50000,
+        "elapsedMs": 4519.6,
+        "actionsPerSec": 11063
+      },
+      "multiWindowPropagation": {
+        "samples": 100,
+        "mean": 17.32,
+        "p50": 17,
+        "p95": 18,
+        "p99": 18,
+        "min": 16,
+        "max": 19
+      },
+      "memory": {
+        "heapBeforeBytes": 25119452,
+        "heapAfterBytes": 35463596,
+        "heapDeltaBytes": 10344144,
+        "note": "Electron main-process Node heap only; native allocations not measured. Becomes more important at 3.2 when the Rust core lands — track delta direction, not absolute size."
+      }
+    },
+    "zustand-basic": {
+      "capturedAt": "2026-06-25T10:35:42.910Z",
+      "platform": "darwin",
+      "dispatchRoundTrip": {
+        "samples": 500,
+        "mean": 17.909,
+        "p50": 17.9,
+        "p95": 19,
+        "p99": 19.3,
+        "min": 16.7,
+        "max": 22.2
+      },
+      "throughput": {
+        "actions": 50000,
+        "elapsedMs": 4654.7,
+        "actionsPerSec": 10742
+      },
+      "multiWindowPropagation": {
+        "samples": 100,
+        "mean": 17.29,
+        "p50": 17,
+        "p95": 18,
+        "p99": 18,
+        "min": 16,
+        "max": 18
+      },
+      "memory": {
+        "heapBeforeBytes": 24914148,
+        "heapAfterBytes": 20652984,
+        "heapDeltaBytes": -4261164,
+        "note": "Electron main-process Node heap only; native allocations not measured. Becomes more important at 3.2 when the Rust core lands — track delta direction, not absolute size."
+      }
+    }
+  }
+}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.4/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/e2e/test/bench-performance.spec.ts
+++ b/e2e/test/bench-performance.spec.ts
@@ -21,13 +21,22 @@ import {
 
 const CORE_WINDOW_COUNT = 2;
 
-// Sample sizes — small enough to keep each WDIO run under a minute, large
-// enough to give stable percentiles. Adjust upward if variance is too high.
+// Sample sizes — large enough for stable percentiles / a steady-state
+// throughput rate, small enough to keep each WDIO run to a few minutes.
 const LATENCY_SAMPLES = 500;
 const LATENCY_WARMUP = 50;
-const THROUGHPUT_ACTIONS = 5000;
 const PROPAGATION_SAMPLES = 100;
-const MEMORY_LOAD_ACTIONS = 10000;
+
+// Throughput + memory feed actions through a bounded in-flight window rather
+// than firing them all at once. The ActionBatcher rejects a queue deeper than
+// its hard limit (max(maxBatchSize * 4, 100) = 200 by default) as a suspected
+// DoS, so an unbounded Promise.all overflows it. Capping concurrency keeps the
+// batcher within contract and measures *sustained* throughput against the
+// unmodified production path — the same path that runs against the 3.2 Rust
+// core, so the 3.1 → 3.2 comparison stays apples-to-apples.
+const THROUGHPUT_ACTIONS = 50000;
+const MEMORY_LOAD_ACTIONS = 50000;
+const MAX_IN_FLIGHT = 100;
 
 // `window.zubridge` is already typed via @zubridge/types' internal augmentation
 // (ZubridgeInternalWindow). We add only the bench-scratch properties.
@@ -101,22 +110,41 @@ describe(`Performance bench (${getMode()})`, () => {
   });
 
   it('measures sustained throughput', async function () {
-    this.timeout(120000);
+    this.timeout(180000);
     await setupTestEnvironment(CORE_WINDOW_COUNT);
     await switchToWindow(0);
 
-    const measurement = await browser.execute(async (count: number) => {
-      const z = window.zubridge;
-      if (!z) throw new Error('window.zubridge not available');
-      const t0 = performance.now();
-      const promises: Promise<unknown>[] = [];
-      for (let i = 0; i < count; i++) {
-        promises.push(z.dispatch('COUNTER:INCREMENT'));
-      }
-      await Promise.all(promises);
-      const elapsedMs = performance.now() - t0;
-      return { count, elapsedMs };
-    }, THROUGHPUT_ACTIONS);
+    const measurement = await browser.execute(
+      async (count: number, maxInFlight: number) => {
+        const z = window.zubridge;
+        if (!z) throw new Error('window.zubridge not available');
+        const t0 = performance.now();
+        let started = 0;
+        let completed = 0;
+        // Keep at most `maxInFlight` dispatches outstanding so the batcher queue
+        // never reaches its hard limit; refill the window as each one resolves.
+        await new Promise<void>((resolve, reject) => {
+          const pump = () => {
+            while (started < count && started - completed < maxInFlight) {
+              started += 1;
+              z.dispatch('COUNTER:INCREMENT').then(() => {
+                completed += 1;
+                if (completed === count) {
+                  resolve();
+                } else {
+                  pump();
+                }
+              }, reject);
+            }
+          };
+          pump();
+        });
+        const elapsedMs = performance.now() - t0;
+        return { count, elapsedMs };
+      },
+      THROUGHPUT_ACTIONS,
+      MAX_IN_FLIGHT,
+    );
 
     result.throughput = {
       actions: measurement.count,
@@ -220,7 +248,7 @@ describe(`Performance bench (${getMode()})`, () => {
   });
 
   it('measures heap growth under sustained load', async function () {
-    this.timeout(120000);
+    this.timeout(180000);
     await setupTestEnvironment(CORE_WINDOW_COUNT);
     await switchToWindow(0);
 
@@ -233,7 +261,7 @@ describe(`Performance bench (${getMode()})`, () => {
     // bench builds do not pass it, so global.gc is undefined and we skip the GC —
     // heap numbers will include allocations from prior tests in the same process.
     // This is acceptable because we report the delta (after − before), not absolute,
-    // and the 10k-action load swamps any pre-existing residue.
+    // and the 50k-action load swamps any pre-existing residue.
     const heapBeforeBytes = await browser.electron.execute(() => {
       if (typeof global.gc === 'function') {
         global.gc();
@@ -241,15 +269,32 @@ describe(`Performance bench (${getMode()})`, () => {
       return process.memoryUsage().heapUsed;
     });
 
-    await browser.execute(async (count: number) => {
-      const z = window.zubridge;
-      if (!z) throw new Error('window.zubridge not available');
-      const promises: Promise<unknown>[] = [];
-      for (let i = 0; i < count; i++) {
-        promises.push(z.dispatch('COUNTER:INCREMENT'));
-      }
-      await Promise.all(promises);
-    }, MEMORY_LOAD_ACTIONS);
+    await browser.execute(
+      async (count: number, maxInFlight: number) => {
+        const z = window.zubridge;
+        if (!z) throw new Error('window.zubridge not available');
+        let started = 0;
+        let completed = 0;
+        await new Promise<void>((resolve, reject) => {
+          const pump = () => {
+            while (started < count && started - completed < maxInFlight) {
+              started += 1;
+              z.dispatch('COUNTER:INCREMENT').then(() => {
+                completed += 1;
+                if (completed === count) {
+                  resolve();
+                } else {
+                  pump();
+                }
+              }, reject);
+            }
+          };
+          pump();
+        });
+      },
+      MEMORY_LOAD_ACTIONS,
+      MAX_IN_FLIGHT,
+    );
 
     const heapAfterBytes = await browser.electron.execute((_electron) => {
       if (typeof global.gc === 'function') {

--- a/e2e/test/bench-performance.spec.ts
+++ b/e2e/test/bench-performance.spec.ts
@@ -262,7 +262,8 @@ describe(`Performance bench (${getMode()})`, () => {
     // The bench launches Electron with --js-flags=--expose-gc (wdio.conf.ts), so
     // global.gc is available and we force a collection before each measurement to
     // strip GC-timing noise from the delta. We assert it's present rather than
-    // silently skipping the GC, so a missing flag fails the bench loudly (#180).
+    // silently skipping the GC, so a missing flag fails the bench loudly.
+    // See https://github.com/goosewobbler/zubridge/issues/180
     const heapBeforeBytes = await browser.electron.execute(() => {
       if (typeof global.gc !== 'function') {
         throw new Error(

--- a/e2e/test/bench-performance.spec.ts
+++ b/e2e/test/bench-performance.spec.ts
@@ -259,16 +259,18 @@ describe(`Performance bench (${getMode()})`, () => {
     // Note: this only captures the Node heap; native allocations (V8 internals,
     // C++ structures held by Electron, Rust core in 3.2+) are not measured.
     //
-    // --expose-gc must be set at Electron startup to make global.gc available;
-    // app.commandLine.appendSwitch after app.ready is a silent no-op. The current
-    // bench builds do not pass it, so global.gc is undefined and we skip the GC —
-    // heap numbers will include allocations from prior tests in the same process.
-    // This is acceptable because we report the delta (after − before), not absolute,
-    // and the 50k-action load swamps any pre-existing residue.
+    // The bench launches Electron with --js-flags=--expose-gc (wdio.conf.ts), so
+    // global.gc is available and we force a collection before each measurement to
+    // strip GC-timing noise from the delta. We assert it's present rather than
+    // silently skipping the GC, so a missing flag fails the bench loudly (#180).
     const heapBeforeBytes = await browser.electron.execute(() => {
-      if (typeof global.gc === 'function') {
-        global.gc();
+      if (typeof global.gc !== 'function') {
+        throw new Error(
+          'global.gc is undefined — the memory bench requires Electron to launch with ' +
+            '--js-flags=--expose-gc (set in wdio.conf.ts for SPEC_FILE=bench-*).',
+        );
       }
+      global.gc();
       return process.memoryUsage().heapUsed;
     });
 
@@ -301,10 +303,13 @@ describe(`Performance bench (${getMode()})`, () => {
       MAX_IN_FLIGHT,
     );
 
-    const heapAfterBytes = await browser.electron.execute((_electron) => {
-      if (typeof global.gc === 'function') {
-        global.gc();
+    const heapAfterBytes = await browser.electron.execute(() => {
+      if (typeof global.gc !== 'function') {
+        throw new Error(
+          'global.gc is undefined — Electron must launch with --js-flags=--expose-gc.',
+        );
       }
+      global.gc();
       return process.memoryUsage().heapUsed;
     });
 

--- a/e2e/test/bench-performance.spec.ts
+++ b/e2e/test/bench-performance.spec.ts
@@ -123,6 +123,9 @@ describe(`Performance bench (${getMode()})`, () => {
         let completed = 0;
         // Keep at most `maxInFlight` dispatches outstanding so the batcher queue
         // never reaches its hard limit; refill the window as each one resolves.
+        // NOTE: this pump loop is duplicated in the memory-growth test below. It can't be
+        // extracted to a shared helper — browser.execute serialises the callback into the
+        // renderer, severing Node-side imports — so keep the two copies in sync.
         await new Promise<void>((resolve, reject) => {
           const pump = () => {
             while (started < count && started - completed < maxInFlight) {
@@ -275,6 +278,8 @@ describe(`Performance bench (${getMode()})`, () => {
         if (!z) throw new Error('window.zubridge not available');
         let started = 0;
         let completed = 0;
+        // Same bounded-in-flight pump as the throughput test above (see the note there);
+        // duplicated because browser.execute can't reference a shared Node-side helper.
         await new Promise<void>((resolve, reject) => {
           const pump = () => {
             while (started < count && started - completed < maxInFlight) {

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -223,7 +223,8 @@ if (currentPlatform === 'linux') {
 
 // The memory bench needs global.gc, which Electron exposes only when launched with
 // --js-flags=--expose-gc (calling appendSwitch after app.ready is a silent no-op).
-// Bench-only — keyed off the SPEC_FILE the test:bench:* scripts set. See #180.
+// Bench-only — keyed off the SPEC_FILE the test:bench:* scripts set.
+// See https://github.com/goosewobbler/zubridge/issues/180
 const benchArgs = process.env.SPEC_FILE?.startsWith('bench-') ? ['--js-flags=--expose-gc'] : [];
 
 const appArgs = process.env.ELECTRON_APP_PATH

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -221,9 +221,14 @@ if (currentPlatform === 'linux') {
   console.log('[DEBUG] Added Linux-specific flags for CI stability');
 }
 
+// The memory bench needs global.gc, which Electron exposes only when launched with
+// --js-flags=--expose-gc (calling appendSwitch after app.ready is a silent no-op).
+// Bench-only — keyed off the SPEC_FILE the test:bench:* scripts set. See #180.
+const benchArgs = process.env.SPEC_FILE?.startsWith('bench-') ? ['--js-flags=--expose-gc'] : [];
+
 const appArgs = process.env.ELECTRON_APP_PATH
-  ? [process.env.ELECTRON_APP_PATH, ...baseArgs]
-  : baseArgs;
+  ? [process.env.ELECTRON_APP_PATH, ...baseArgs, ...benchArgs]
+  : [...baseArgs, ...benchArgs];
 
 // Determine which spec files to run based on the mode
 let specPattern: string | string[];


### PR DESCRIPTION
## Problem

The perf bench's throughput (5k) and memory (10k) scenarios fired every dispatch in parallel, overflowing the `ActionBatcher` hard queue limit (`max(maxBatchSize * 4, 100)` = 200), which rejects the excess as a suspected DoS. The run aborted after the first mode, so no complete baseline could be captured.

## Change

- **Bounded in-flight window**: feed actions with ≤100 outstanding, refilling as each resolves. The batcher stays within contract and we measure *sustained* throughput against the **unmodified production path** — the same methodology will run against the 3.2 Rust core, keeping the 3.1 → 3.2 comparison apples-to-apples.
- Bump throughput/memory totals to 50k, timeouts to 180s.
- Capture `benches/baseline.json` against the 3.0 TS core.

## v3.0 baseline (local macOS · Electron 42.4.0 · Node 24.14)

| Metric | zustand-basic | redux | custom |
|---|---|---|---|
| Dispatch round-trip p50 / p99 (ms) | 17.9 / 19.3 | 17.9 / 19.5 | 18.0 / 19.2 |
| Throughput (actions/sec) | 10,742 | 11,063 | 10,964 |
| Multi-window propagation p50 / p99 (ms) | 17 / 18 | 17 / 18 | 17 / 19 |
| Heap Δ / 50k load (bytes) | −4.26M | +10.34M | −2.07M |

Latency & propagation cluster at ~17–18ms (the 16ms batcher flush window dominating); throughput ~11k/sec regardless of state backend (IPC round-trip dominates). Internally consistent.

## Caveats

- **Local hardware** — absolute numbers are machine-specific. The authoritative regression-gate baseline should be re-captured on the pinned CI runner (same hardware as the comparison runs).
- **Memory metric is indicative-only** — the bench builds don't pass `--js-flags=--expose-gc`, so `global.gc` is undefined and heap-delta is GC-timing noise (two modes went negative). Tracked in #180; should land with the CI-runner capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the performance bench's concurrency overflow by replacing unbounded `Promise.all` with a sliding-window pump that keeps at most 100 in-flight dispatches, ensuring the `ActionBatcher` queue stays within its hard limit. It also bumps action counts to 50k, extends timeouts to 180s, adds `--js-flags=--expose-gc` to the bench startup args so `global.gc` is reliable (and now throws rather than silently skipping), and commits a local macOS baseline for v3.0.

- **`e2e/test/bench-performance.spec.ts`**: Old unbounded `Promise.all` replaced with a sliding-window pump (`MAX_IN_FLIGHT = 100`); `THROUGHPUT_ACTIONS` and `MEMORY_LOAD_ACTIONS` bumped from 5k/10k to 50k; `global.gc` guard changed from silent skip to hard throw; test timeouts extended to 180s.
- **`e2e/wdio.conf.ts`**: Conditionally appends `--js-flags=--expose-gc` to Electron startup args when `SPEC_FILE` starts with `bench-`, so the flag is set before `app.ready` rather than via the no-op `appendSwitch` path.
- **`benches/baseline.json`**: Machine-local v3.0 baseline captured on macOS; memory deltas are acknowledged as GC-noise (flag was not yet active when captured) and noted as indicative-only.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the bounded-window pump is logically correct, the Electron flag is conditioned correctly on SPEC_FILE, and all caveats about the local baseline are documented.

The sliding-window pump correctly maintains at most MAX_IN_FLIGHT outstanding dispatches: each completion increments completed, re-checks the window, and starts exactly one replacement dispatch until started === count. The --js-flags=--expose-gc flag is gated on SPEC_FILE starting with bench-, matching the test:bench:* npm scripts. No production code is touched; the baseline.json caveats are fully documented.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| e2e/test/bench-performance.spec.ts | Replaces unbounded Promise.all with a correct sliding-window pump; bumps sample sizes and timeouts; tightens global.gc guard to fail loudly |
| e2e/wdio.conf.ts | Conditionally adds --js-flags=--expose-gc for bench spec files so global.gc is available in the Electron main process at startup |
| benches/baseline.json | Adds local macOS v3.0 baseline; memory deltas are GC-noise (flag not active at capture time) and documented as indicative-only |
| biome.jsonc | Schema reference changed from pinned remote URL to local node_modules path (previously reviewed) |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pump called] --> B{started < count AND started - completed < maxInFlight?}
    B -- yes --> C[started += 1, dispatch fired]
    C --> D[.then resolve handler, completed += 1]
    D --> E{completed === count?}
    E -- yes --> F[resolve outer Promise, record elapsedMs]
    E -- no --> A
    B -- no --> G[return / wait for next .then callback]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["test(perf): link the #180 issue as a ful..."](https://github.com/goosewobbler/zubridge/commit/b3609835d1b6896a7fac335ebc364bcaad4994a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39802546)</sub>

<!-- /greptile_comment -->