### PR TITLE
docs(tauri): add Tauri v2 manual test checklist

### DIFF
--- a/apps/tauri/e2e/MANUAL-TEST.md
+++ b/apps/tauri/e2e/MANUAL-TEST.md
@@ -1,0 +1,117 @@
+# Tauri v2 — Manual Test Checklist
+
+> Pre-release validation for `@zubridge/tauri` v2 (UniFFI refactor P4). Focuses on the
+> newly-ported **scheduler / thunk / batching / subscription** paths, which currently have
+> only Rust unit tests + one smoke E2E spec (`test/specs/basic-sync.spec.ts`). Findings here
+> drive the automated-suite expansion (Phase 4).
+
+## Setup
+
+```bash
+# From repo root. First run compiles the Rust plugin (slow); subsequent runs are fast.
+cd apps/tauri/e2e
+cross-env DEBUG=zubridge:* pnpm dev:zustand-basic   # swap mode per the matrix below
+```
+
+- Open the **webview devtools console** (renderer logs) *and* watch the **terminal** (Rust
+  plugin logs) — `DEBUG=zubridge:*` traces IPC / batch / thunk lifecycle on both sides.
+- Controls live in the counter panel: increment/decrement, the various "Double counter
+  using …" buttons (action / main-process thunk / renderer thunk / getState-override / slow
+  variants), "Apply distinctive pattern" (×3, +2, −1 → `3N+1`), subscribe/unsubscribe, and
+  create/close window.
+- When something looks wrong, **run the same step in the equivalent Electron minimal app** to
+  decide: Tauri-specific regression vs. expected behaviour.
+
+## Mode matrix
+
+Run the **P0 + P1** sections in each mode; P2 once is enough. Prioritise `custom` and the
+sync-handler modes — they take different code paths.
+
+| Mode | Why it matters |
+|---|---|
+| `zustand-basic` | Baseline happy path |
+| `zustand-handlers` | Handler-based dispatch |
+| `zustand-reducers` | **Sync handlers** (different thunk variant) |
+| `redux` | **Sync handlers** + Redux semantics |
+| `custom` | Custom state manager — highest parity risk |
+
+---
+
+## P0 — Highest value (scheduler / thunk / concurrency; untested via E2E)
+
+**Thunk correctness**
+
+- [ ] **Main-process thunk** ("Double counter using main process thunk"): from a known value,
+      counter doubles; value propagates to all open windows.
+- [ ] **Renderer thunk** ("…using renderer thunk"): doubles correctly.
+- [ ] **getState-override thunk** ("…with getState override"): result reflects the *overridden*
+      state, not the live counter (verifies the override path).
+- [ ] **Distinctive pattern** (×3, +2, −1): from value N, final == `3N+1` (e.g. 5 → 16). With
+      DEBUG on, the three steps apply as one clean sequence.
+
+**Thunk atomicity under concurrency (the key test)**
+
+- [ ] Start a **slow** thunk (e.g. "slow main process thunk" or "distinctive pattern slowly").
+      *While it runs*, rapidly click **Increment** in the **same** window. Expected (Electron
+      parity): non-immediate actions queue and apply *after* the thunk; final value is
+      consistent and steps don't interleave mid-pattern.
+- [ ] Same, but fire the increments from a **second window** while the slow thunk runs in the
+      first. Final state must be identical in both windows.
+- [ ] Fire **two slow thunks** back-to-back. Verify they don't corrupt each other (sequential,
+      correct final value) — parent/child + root-thunk handling.
+
+**Action scheduling / batching**
+
+- [ ] Rapid-fire **Increment** ~25× as fast as possible → every click lands (no dropped
+      actions), final value exact. DEBUG should show batched dispatches, not 25 individual
+      round-trips.
+- [ ] Rapid alternating Increment/Decrement → final value matches net clicks; ordering preserved.
+
+---
+
+## P1 — Important (multi-window, subscriptions, errors)
+
+**Multi-window sync**
+
+- [ ] Open a **secondary window** (create window); both show the same counter; changes propagate
+      **bidirectionally**.
+- [ ] Increment to a non-zero value, *then* open a **new** window → it hydrates to the **current**
+      state (not 0).
+- [ ] Open **3+ windows** → all stay in sync under mixed activity.
+- [ ] **Close** a window mid-activity → no errors in the others; remaining windows keep syncing
+      (subscription cleanup).
+
+**Subscriptions**
+
+- [ ] Subscribe a window to **only `counter`** → change **theme** elsewhere → that window does
+      **not** receive theme updates; counter changes still arrive.
+- [ ] **Unsubscribe** → updates stop. **Re-subscribe** → updates resume.
+- [ ] `getWindowSubscriptions` / the displayed subscription state reflects reality after each
+      change.
+- [ ] Two windows with **different** subscriptions behave independently.
+
+**Error handling**
+
+- [ ] Trigger **main-process error** (`ERROR:TRIGGER_MAIN_PROCESS_ERROR`) → error surfaces
+      (rejected dispatch / logged), **app does not crash**, state stays consistent, and
+      **subsequent actions still work**.
+- [ ] Window-create error path behaves gracefully.
+
+---
+
+## P2 — Coverage (other state, lifecycle)
+
+- [ ] **Theme toggle/set** propagates to all windows.
+- [ ] **STATE:RESET** returns to initial state everywhere.
+- [ ] **COUNTER:SET / HALVE / DOUBLE** (direct actions, non-thunk) behave correctly.
+- [ ] **Reload** a window (devtools reload) → re-syncs to current state, no duplicate
+      subscriptions / leaks.
+- [ ] Leave the app idle a minute, then act → no stale state / no missed updates.
+
+---
+
+## Recording findings
+
+For anything that fails or looks off, capture: **mode**, **steps**, **expected vs actual**,
+**DEBUG log snippet** (renderer + Rust), and **whether Electron does the same**. That format
+drops straight into a Phase 4 E2E spec or a bug issue.

--- a/apps/tauri/e2e/MANUAL-TEST.md
+++ b/apps/tauri/e2e/MANUAL-TEST.md
@@ -37,28 +37,41 @@ sync-handler modes — they take different code paths.
 
 ---
 
-## P0 — Highest value (scheduler / thunk / concurrency; untested via E2E)
+## P0 — Highest value (scheduler / thunk / concurrency)
+
+> **Prerequisites:** merge **#187** (scheduler wiring) and **#188** (backend thunks), then rebuild
+> (`pnpm build:tauri`, or `cd apps/tauri/e2e && pnpm dev:<mode>`). The action scheduler is now wired
+> into the plugin, so thunks genuinely **block** concurrent actions (before this they did not). The
+> "Main Thunk" buttons now appear and work on Tauri. Some paths below are E2E-covered
+> (`renderer-thunk.spec.ts`, `backend-thunk.spec.ts`) — the manual pass focuses on the variants and
+> modes those don't reach.
 
 **Thunk correctness**
 
-- [ ] **Main-process thunk** ("Double counter using main process thunk"): from a known value,
-      counter doubles; value propagates to all open windows.
-- [ ] **Renderer thunk** ("…using renderer thunk"): doubles correctly.
+- [ ] **Backend ("main process") thunk** ("Double counter using main process thunk"): a thunk
+      authored in **Rust** (Tauri has no JS main process — see #185). Counter doubles and propagates
+      to all windows. *E2E-covered (`backend-thunk.spec.ts`)*; spot-check across modes.
+- [ ] **Renderer thunk** ("…using renderer thunk"): doubles correctly. *E2E-covered
+      (`renderer-thunk.spec.ts`)*; spot-check across modes.
 - [ ] **getState-override thunk** ("…with getState override"): result reflects the *overridden*
-      state, not the live counter (verifies the override path).
+      state, not the live counter (verifies the override path). **Not E2E-covered — test here.**
 - [ ] **Distinctive pattern** (×3, +2, −1): from value N, final == `3N+1` (e.g. 5 → 16). With
-      DEBUG on, the three steps apply as one clean sequence.
+      DEBUG on, the three steps apply as one clean sequence. **Not E2E-covered — test here.**
 
-**Thunk atomicity under concurrency (the key test)**
+**Thunk atomicity under concurrency (the behaviour PR #187 unlocks)**
 
-- [ ] Start a **slow** thunk (e.g. "slow main process thunk" or "distinctive pattern slowly").
-      *While it runs*, rapidly click **Increment** in the **same** window. Expected (Electron
-      parity): non-immediate actions queue and apply *after* the thunk; final value is
-      consistent and steps don't interleave mid-pattern.
-- [ ] Same, but fire the increments from a **second window** while the slow thunk runs in the
-      first. Final state must be identical in both windows.
-- [ ] Fire **two slow thunks** back-to-back. Verify they don't corrupt each other (sequential,
-      correct final value) — parent/child + root-thunk handling.
+With the scheduler wired, non-thunk actions dispatched while a thunk runs **queue and apply only
+after it completes** — they no longer interleave with the thunk's steps. The slow backend thunk is
+~3s, giving you time to interleave.
+
+- [ ] Start a **slow backend thunk** ("slow main process thunk"). *While it runs*, click
+      **Increment** a few times in the **same** window → the increments do **not** take effect until
+      the thunk completes, then they all apply at once.
+- [ ] Same, but fire the increments from a **second window** while the slow thunk runs in the first
+      → both windows converge to the same final value. *(E2E-covered for the backend slow thunk;
+      verify the **renderer** slow thunk + the non-default modes here.)*
+- [ ] Repeat with the **slow renderer thunk** and **distinctive pattern slowly** — same blocking.
+- [ ] Fire **two slow thunks** back-to-back → sequential, correct final value (root-thunk handling).
 
 **Action scheduling / batching**
 

--- a/apps/tauri/e2e/MANUAL-TEST.md
+++ b/apps/tauri/e2e/MANUAL-TEST.md
@@ -10,7 +10,7 @@
 ```bash
 # From repo root. First run compiles the Rust plugin (slow); subsequent runs are fast.
 cd apps/tauri/e2e
-cross-env DEBUG=zubridge:* pnpm dev:zustand-basic   # swap mode per the matrix below
+DEBUG=zubridge:* pnpm dev:zustand-basic   # swap mode per the matrix below
 ```
 
 - Open the **webview devtools console** (renderer logs) *and* watch the **terminal** (Rust
@@ -27,13 +27,13 @@ cross-env DEBUG=zubridge:* pnpm dev:zustand-basic   # swap mode per the matrix b
 Run the **P0 + P1** sections in each mode; P2 once is enough. Prioritise `custom` and the
 sync-handler modes — they take different code paths.
 
-| Mode | Why it matters |
-|---|---|
-| `zustand-basic` | Baseline happy path |
-| `zustand-handlers` | Handler-based dispatch |
-| `zustand-reducers` | **Sync handlers** (different thunk variant) |
-| `redux` | **Sync handlers** + Redux semantics |
-| `custom` | Custom state manager — highest parity risk |
+| Mode | Command | Why it matters |
+|---|---|---|
+| `zustand-basic` | `pnpm dev:zustand-basic` | Baseline happy path |
+| `zustand-handlers` | `pnpm dev:zustand-handlers` | Handler-based dispatch |
+| `zustand-reducers` | `pnpm dev:zustand-reducers` | **Sync handlers** (different thunk variant) |
+| `redux` | `pnpm dev:redux` | **Sync handlers** + Redux semantics |
+| `custom` | `pnpm dev:custom` | Custom state manager — highest parity risk |
 
 ---
 


### PR DESCRIPTION
Pre-release validation checklist for `@zubridge/tauri` v2 (UniFFI refactor P4), saved at `apps/tauri/e2e/MANUAL-TEST.md`.

## Why

The newly-ported **scheduler / thunk / batching / subscription** logic currently has only Rust unit tests and one smoke E2E spec (`basic-sync.spec.ts`). Before cutting v2 we want a hands-on pass over the paths that have no end-to-end coverage. This checklist is grounded in the controls the app actually exposes (`@zubridge/ui` + `@zubridge/apps-shared`): main-process / renderer / getState-override / slow thunks, the distinctive multi-step pattern, subscriptions, runtime windows, and the deliberate main-process error trigger.

## Structure

- Setup + `DEBUG=zubridge:*` launch per mode.
- Per-mode matrix (prioritising `custom` and the sync-handler modes).
- **P0** — thunk correctness + atomicity under concurrency + scheduling/batching (highest value, untested via E2E).
- **P1** — multi-window sync, subscriptions, error handling.
- **P2** — other state + lifecycle.
- A findings-recording format that drops straight into Phase 4 E2E specs or bug issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single markdown file, `apps/tauri/e2e/MANUAL-TEST.md`, which is a structured pre-release validation checklist for `@zubridge/tauri` v2 covering paths not yet reached by automated E2E specs.

- **Setup block** uses a bare `DEBUG=zubridge:*` shell prefix (not `cross-env` directly), correctly delegating cross-platform env-var handling to the `pnpm` scripts already defined in `package.json`.
- **Mode matrix** now includes the `pnpm dev:<mode>` command for each of the five modes, removing ambiguity for testers unfamiliar with the project.
- **P0 / P1 / P2 tiers** are well-grounded in the actual UI controls and cover the scheduler/thunk/concurrency paths that have no automated E2E coverage yet.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change adding a markdown checklist file; no runtime code is touched.

The only changed file is a new markdown checklist. The setup command correctly uses a bare shell-prefix for DEBUG rather than invoking cross-env directly, the mode matrix includes commands for all five modes, and the test tiers are accurately grounded in the UI controls and existing spec coverage. No functional code is modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/tauri/e2e/MANUAL-TEST.md | New manual test checklist for Tauri v2 pre-release. Well-structured with mode matrix (including commands), prioritised P0/P1/P2 tiers, and a findings-recording format. No logic or runtime issues. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Setup: cd apps/tauri/e2e\nDEBUG=zubridge:* pnpm dev:<mode>] --> B{Merge PRs\n#187 + #188?}
    B -- No --> C[Skip P0 thunk-atomicity tests]
    B -- Yes --> D[P0: Scheduler / Thunk / Concurrency]

    D --> D1[Thunk correctness\nbackend / renderer / getState-override / distinctive]
    D --> D2[Thunk atomicity\nslow thunk + concurrent increments queued]
    D --> D3[Action batching\nrapid-fire 25x exact count, batched IPC]

    A --> E[P1: Multi-window / Subscriptions / Errors]
    E --> E1[Multi-window sync\nbidirectional, late-join hydration]
    E --> E2[Subscriptions\ncounter-only, unsub/resub, per-window]
    E --> E3[Error handling\nmain-process error no crash, state stable]

    A --> F[P2: Coverage once is enough]
    F --> F1[Theme, STATE:RESET, direct actions]
    F --> F2[Window reload re-sync, no leaks]
    F --> F3[Idle then act no stale state]

    D1 & D2 & D3 & E1 & E2 & E3 & F1 & F2 & F3 --> G[Record findings\nmode + steps + expected vs actual\n+ DEBUG log + Electron comparison]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["docs(tauri): add per-mode commands and d..."](https://github.com/goosewobbler/zubridge/commit/db678708807cbafa9eaab6859795c82dab9b38be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39805502)</sub>

<!-- /greptile_comment -->