### PR TITLE
fix(ui): gate main-process-thunk buttons on platform capability

### DIFF
--- a/packages/ui/src/components/AppBase/ZubridgeApp.tsx
+++ b/packages/ui/src/components/AppBase/ZubridgeApp.tsx
@@ -392,6 +392,7 @@ export function ZubridgeApp({
                     });
                   }}
                   isLoading={bridgeStatus === 'initializing'}
+                  supportsMainThunk={!!window.counter?.executeMainThunk}
                 />
               </div>
 

--- a/packages/ui/src/components/CounterActions/index.tsx
+++ b/packages/ui/src/components/CounterActions/index.tsx
@@ -10,6 +10,12 @@ interface CounterActionsProps {
   onDistinctive?: (method: CounterMethod) => void;
   isLoading?: boolean;
   className?: string;
+  /**
+   * Whether the platform can run a thunk in its main process. Only Electron can
+   * (its main process is Node/JS); Tauri's main process is native Rust with no
+   * JS runtime, so the main-thunk buttons are hidden there. Defaults to false.
+   */
+  supportsMainThunk?: boolean;
 }
 
 /**
@@ -22,6 +28,7 @@ export const CounterActions: React.FC<CounterActionsProps> = ({
   onDistinctive,
   isLoading = false,
   className = '',
+  supportsMainThunk = false,
 }) => {
   const rootClass = clsx('max-w-[theme(--container-width)] mx-auto my-5 mt-[60px]', className);
 
@@ -71,22 +78,26 @@ export const CounterActions: React.FC<CounterActionsProps> = ({
         >
           Double (Renderer Slow Thunk)
         </Button>
-        <Button
-          onClick={() => onDouble('main-thunk')}
-          disabled={isLoading}
-          aria-label="Double counter using main process thunk"
-          className="w-full"
-        >
-          Double (Main Thunk)
-        </Button>
-        <Button
-          onClick={() => onDouble('slow-main-thunk')}
-          disabled={isLoading}
-          aria-label="Double counter using slow main process thunk"
-          className="w-full"
-        >
-          Double (Main Slow Thunk)
-        </Button>
+        {supportsMainThunk && (
+          <>
+            <Button
+              onClick={() => onDouble('main-thunk')}
+              disabled={isLoading}
+              aria-label="Double counter using main process thunk"
+              className="w-full"
+            >
+              Double (Main Thunk)
+            </Button>
+            <Button
+              onClick={() => onDouble('slow-main-thunk')}
+              disabled={isLoading}
+              aria-label="Double counter using slow main process thunk"
+              className="w-full"
+            >
+              Double (Main Slow Thunk)
+            </Button>
+          </>
+        )}
         {onDistinctive && (
           <Button
             onClick={() => onDistinctive('thunk')}


### PR DESCRIPTION
Found during the Tauri v2 manual test pass (#3 / manual checklist): the **"Double (Main Thunk)"** and **"(Main Slow Thunk)"** buttons throw `Main thunk execution not available` on Tauri.

## Root cause

`CounterActions` rendered both buttons unconditionally, but they call `window.counter.executeMainThunk()` — a hook only **Electron's preload** exposes (`apps/electron/e2e/src/preload/index.ts`). The Tauri e2e app never assigns `window.counter`, and `commands.rs` has no `execute_main_thunk` command, so the shared UI's `if (!window.counter?.executeMainThunk)` guard rejects.

This isn't a simple omission: a *main-process thunk* is a JS thunk executing in the main process. Electron's main process is Node/JS (`mainThunkProcessor.ts`); Tauri's is **native Rust with no JS runtime** (`@zubridge/tauri` has only `rendererThunkProcessor.ts`). An Electron-style main thunk **cannot exist** on Tauri.

## Fix

- New `supportsMainThunk?: boolean` prop on `CounterActions` (default `false`) gates the two buttons.
- `ZubridgeApp` opts in via `!!window.counter?.executeMainThunk`.
- Result: **Electron** shows them (capability provably present); **Tauri v1/v2** hide them. Auto-enables if a Rust-side equivalent is ever wired. No adapter change; renderer thunks / direct actions unaffected.

## Scope / follow-up

- This **unblocks the manual test pass** (the buttons no longer present a capability the platform can't honour).
- The deeper question — should Tauri v2 ship a **Rust-side main-thunk equivalent** for parity? — is tracked in #185.
- `@zubridge/ui` has no unit-test setup, so there's no seam to lock this down here; the regression test is an E2E spec in the Phase 4 expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the "Double (Main Thunk)" and "Double (Main Slow Thunk)" buttons were unconditionally rendered in the shared UI, causing errors on Tauri (which has no JS runtime in its main process and therefore no `window.counter.executeMainThunk`). The fix gates these buttons on a new `supportsMainThunk` prop, defaulting to `false`, and opts Electron in via `!!window.counter?.executeMainThunk`.

- `CounterActions` gains an optional `supportsMainThunk?: boolean` prop (default `false`) that conditionally renders the two main-thunk buttons.
- `ZubridgeApp` passes `!!window.counter?.executeMainThunk` as the prop value, so Electron shows the buttons and Tauri hides them with no adapter changes required.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-file, additive capability guard with a safe default of false.

The fix is minimal: one new optional prop with a safe default, one inline capability check using optional chaining. The guard correctly evaluates to false on Tauri (no window.counter) and true on Electron (preload populates window.counter before any JS runs), so there are no timing concerns. No existing functionality is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/CounterActions/index.tsx | Adds optional `supportsMainThunk` prop (default `false`) to gate the two main-thunk buttons; implementation is clean and well-documented. |
| packages/ui/src/components/AppBase/ZubridgeApp.tsx | Passes `!!window.counter?.executeMainThunk` as `supportsMainThunk`; safely uses optional chaining so Tauri (no `window.counter`) evaluates to `false`. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ZubridgeApp renders CounterActions] --> B{window.counter?.executeMainThunk}
    B -- truthy Electron preload present --> C[supportsMainThunk = true]
    B -- falsy Tauri / no preload --> D[supportsMainThunk = false]
    C --> E[CounterActions renders Main Thunk + Main Slow Thunk buttons]
    D --> F[CounterActions hides Main Thunk + Main Slow Thunk buttons]
    E --> G[User can invoke main-process thunk]
    F --> H[Only renderer thunk & object buttons shown]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): gate main-process-thunk buttons..."](https://github.com/goosewobbler/zubridge/commit/3cbe9409e1361d75c39b57b75b9632ca36384af0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39809102)</sub>

<!-- /greptile_comment -->