### PR TITLE
feat(tauri-plugin): route dispatch through the action scheduler

### DIFF
--- a/apps/tauri/e2e/test/specs/renderer-thunk.spec.ts
+++ b/apps/tauri/e2e/test/specs/renderer-thunk.spec.ts
@@ -1,0 +1,42 @@
+import { browser } from '@wdio/globals';
+import { beforeEach, describe, it } from 'mocha';
+import { resetCounter, waitForCounterValue } from '../utils/counter.js';
+import { setupTestEnvironment, switchToWindow } from '../utils/window.js';
+
+// Exercises a renderer thunk end-to-end through the wired action scheduler:
+// register_thunk -> the thunk's own actions execute immediately (they belong to
+// the active root) -> complete_thunk drains the queue and unblocks. Guards
+// against the scheduler wiring regressing the renderer-thunk path (basic-sync
+// only covers plain dispatch).
+describe('Tauri Renderer Thunk (through scheduler)', () => {
+  beforeEach(async () => {
+    await setupTestEnvironment();
+    await resetCounter();
+  });
+
+  it('doubles the counter via a renderer thunk, propagates, and unblocks after', async () => {
+    await switchToWindow('main');
+
+    const inc = await browser.$('[aria-label="Increment counter"]');
+    for (let i = 0; i < 5; i++) {
+      await inc.click();
+    }
+    await waitForCounterValue(5);
+
+    // doubleCounter thunk: getState -> DOUBLE -> DOUBLE -> HALVE (net x2). 5 -> 10.
+    const thunkBtn = await browser.$('[aria-label="Double counter using renderer thunk"]');
+    await thunkBtn.click();
+    await waitForCounterValue(10);
+
+    // The doubled value reached the other window.
+    await switchToWindow('secondary');
+    await waitForCounterValue(10);
+
+    // A plain action after the thunk still applies — confirms the scheduler
+    // unblocked when the thunk completed (otherwise it would queue forever).
+    await switchToWindow('main');
+    const incAfter = await browser.$('[aria-label="Increment counter"]');
+    await incAfter.click();
+    await waitForCounterValue(11);
+  });
+});

--- a/packages/core/src/orchestration/mod.rs
+++ b/packages/core/src/orchestration/mod.rs
@@ -81,8 +81,17 @@ impl ActionQueueManager {
         match self.scheduler.enqueue(action, source_label, &ctx) {
             EnqueueResult::ExecuteNow(queued) => {
                 let new_state = self.execute_action(queued)?;
-                // After any execution, drain any newly unblocked queue items.
-                self.drain_queue()?;
+                // Draining here is a no-op: executing an immediate action doesn't change
+                // thunk state, so it can't unblock a queued action. Queued actions are
+                // drained — with their states returned for the platform to broadcast — by
+                // on_thunk_complete / on_label_forgotten. Assert the invariant so a future
+                // change that breaks it fails loudly instead of silently dropping states.
+                let drained = self.drain_queue()?;
+                debug_assert!(
+                    drained.is_empty(),
+                    "immediate execution unexpectedly unblocked {} queued action(s)",
+                    drained.len()
+                );
                 Ok(Some(new_state))
             }
             EnqueueResult::Queued => Ok(None),

--- a/packages/core/src/orchestration/mod.rs
+++ b/packages/core/src/orchestration/mod.rs
@@ -13,6 +13,19 @@ use crate::models::{JsonValue, StateManager, ZubridgeAction};
 use crate::state::StateManagerHandle;
 use crate::thunk::{ThunkEvent, ThunkManager};
 
+// ── DrainedState ──────────────────────────────────────────────────────────────
+
+/// A state update produced by draining a queued action, tagged with the
+/// originating action's provenance so the platform layer can attribute the
+/// broadcast (matching the `source` metadata carried by an immediately
+/// dispatched action's broadcast) instead of emitting it anonymously.
+#[derive(Debug, Clone)]
+pub struct DrainedState {
+    pub state: JsonValue,
+    pub action_id: Option<String>,
+    pub thunk_id: Option<String>,
+}
+
 // ── ActionQueueManager ────────────────────────────────────────────────────────
 
 /// Central orchestrator for action dispatch and thunk lifecycle.
@@ -88,7 +101,7 @@ impl ActionQueueManager {
         &mut self,
         thunk_id: &str,
         error: Option<String>,
-    ) -> Result<(Vec<ThunkEvent>, Vec<JsonValue>)> {
+    ) -> Result<(Vec<ThunkEvent>, Vec<DrainedState>)> {
         let (_, events) = match self.thunk_manager.complete(thunk_id, error) {
             Ok(result) => result,
             Err(_) => return Ok((Vec::new(), Vec::new())), // Thunk not found — ignore.
@@ -99,6 +112,18 @@ impl ActionQueueManager {
         let states = self.drain_queue()?;
 
         Ok((events, states))
+    }
+
+    /// Called by the platform layer when a webview is destroyed.
+    ///
+    /// Drops every thunk owned by `source_label` and drains any actions that
+    /// were queued behind them, returning their states for the platform layer
+    /// to broadcast. Without this drain a destroyed window's blocking thunk
+    /// would leave its dependent actions stuck in the scheduler indefinitely —
+    /// the same escape valve as [`on_thunk_complete`], for the teardown path.
+    pub fn on_label_forgotten(&mut self, source_label: &str) -> Result<Vec<DrainedState>> {
+        self.thunk_manager.drop_label(source_label);
+        self.drain_queue()
     }
 
     /// Register a thunk.
@@ -167,8 +192,9 @@ impl ActionQueueManager {
 
     /// Drain all immediately-eligible actions from the queue and execute them.
     ///
-    /// Returns the new state produced by each executed action in order.
-    fn drain_queue(&mut self) -> Result<Vec<JsonValue>> {
+    /// Returns the new state produced by each executed action in order, tagged
+    /// with that action's provenance (captured before the action is consumed).
+    fn drain_queue(&mut self) -> Result<Vec<DrainedState>> {
         let mut states = Vec::new();
         loop {
             let ctx = self.thunk_manager.scheduler_context();
@@ -177,7 +203,14 @@ impl ActionQueueManager {
                 break;
             }
             for queued in ready {
-                states.push(self.execute_action(queued)?);
+                let action_id = queued.action.id.clone();
+                let thunk_id = queued.action.thunk_parent_id.clone();
+                let state = self.execute_action(queued)?;
+                states.push(DrainedState {
+                    state,
+                    action_id,
+                    thunk_id,
+                });
             }
         }
         Ok(states)
@@ -330,8 +363,35 @@ mod tests {
         let (_events, states) = mgr.on_thunk_complete("t1", None).unwrap();
         assert_eq!(mgr.queue_len(), 0);
         assert_eq!(states.len(), 2, "one state per drained action");
-        assert_eq!(states[0], serde_json::json!({ "count": 1 }));
-        assert_eq!(states[1], serde_json::json!({ "count": 2 }));
+        assert_eq!(states[0].state, serde_json::json!({ "count": 1 }));
+        assert_eq!(states[1].state, serde_json::json!({ "count": 2 }));
+        // Provenance is threaded through so drained broadcasts can be attributed.
+        assert!(
+            states[0].action_id.is_some(),
+            "drained state carries the originating action id"
+        );
+    }
+
+    #[test]
+    fn queue_drained_when_label_forgotten() {
+        let (mut mgr, counter) = manager();
+
+        mgr.register_thunk("t1".into(), None, "main".into(), None, false, false)
+            .unwrap();
+        mgr.execute_thunk("t1");
+
+        // Queue two normal actions behind the active thunk.
+        mgr.dispatch(action("INC"), "main".into()).unwrap();
+        mgr.dispatch(action("INC"), "main".into()).unwrap();
+        assert_eq!(mgr.queue_len(), 2);
+        assert_eq!(*counter.lock().unwrap(), 0);
+
+        // The window owning t1 is destroyed — dropping its thunk must drain the
+        // actions queued behind it instead of leaving them stuck forever.
+        let drained = mgr.on_label_forgotten("main").unwrap();
+        assert_eq!(mgr.queue_len(), 0);
+        assert_eq!(*counter.lock().unwrap(), 2);
+        assert_eq!(drained.len(), 2, "both queued actions drained");
     }
 
     #[test]

--- a/packages/tauri-plugin/src/core/mod.rs
+++ b/packages/tauri-plugin/src/core/mod.rs
@@ -1,6 +1,7 @@
 // Re-export from zubridge_core so existing code in desktop.rs and commands/
 // can continue using `crate::core::*` without modification.
 pub use zubridge_core::deltas::{DeltaCalculator, DeltaResult};
+pub use zubridge_core::orchestration::ActionQueueManager;
 pub use zubridge_core::state::StateManagerHandle;
 pub use zubridge_core::subscription::SubscriptionManager;
 pub use zubridge_core::thunk::{StateUpdateTracker, ThunkRegistry};

--- a/packages/tauri-plugin/src/core/mod.rs
+++ b/packages/tauri-plugin/src/core/mod.rs
@@ -1,7 +1,7 @@
 // Re-export from zubridge_core so existing code in desktop.rs and commands/
 // can continue using `crate::core::*` without modification.
 pub use zubridge_core::deltas::{DeltaCalculator, DeltaResult};
-pub use zubridge_core::orchestration::ActionQueueManager;
+pub use zubridge_core::orchestration::{ActionQueueManager, DrainedState};
 pub use zubridge_core::state::StateManagerHandle;
 pub use zubridge_core::subscription::SubscriptionManager;
 pub use zubridge_core::thunk::{StateUpdateTracker, ThunkRegistry};

--- a/packages/tauri-plugin/src/desktop.rs
+++ b/packages/tauri-plugin/src/desktop.rs
@@ -5,8 +5,10 @@ use serde_json::json;
 use tauri::{plugin::PluginApi, AppHandle, Emitter, Manager, Runtime};
 use uuid::Uuid;
 
-use crate::core::{DeltaCalculator, DeltaResult, StateUpdateTracker, SubscriptionManager, ThunkRegistry};
 use crate::core::state_manager::{self, StateManagerHandle};
+use crate::core::{
+    ActionQueueManager, DeltaCalculator, DeltaResult, StateUpdateTracker, SubscriptionManager,
+};
 use crate::models::{
     BatchDispatchResult, BatchFailure, JsonValue, StateManager, StateUpdatePayload, UpdateSource,
     ZubridgeAction, ZubridgeOptions,
@@ -39,7 +41,7 @@ pub fn init<R: Runtime, C: DeserializeOwned>(
         options: ZubridgeOptions::default(),
         subscriptions: Arc::new(RwLock::new(SubscriptionManager::new())),
         deltas: Arc::new(RwLock::new(DeltaCalculator::new())),
-        thunks: Arc::new(RwLock::new(ThunkRegistry::new())),
+        manager: Arc::new(Mutex::new(None)),
         update_tracker: Arc::new(RwLock::new(StateUpdateTracker::new())),
         sequences: Arc::new(RwLock::new(SequenceTracker::default())),
         broadcast_lock: Arc::new(Mutex::new(())),
@@ -52,12 +54,17 @@ pub struct Zubridge<R: Runtime> {
     options: ZubridgeOptions,
     subscriptions: Arc<RwLock<SubscriptionManager>>,
     deltas: Arc<RwLock<DeltaCalculator>>,
-    thunks: Arc<RwLock<ThunkRegistry>>,
+    /// Central orchestrator (priority scheduler + thunk lifecycle + state
+    /// handle). Lazily constructed on first use from the registered state
+    /// manager — `init` runs before a state manager may exist, so we defer
+    /// construction to the first dispatch/thunk call (see `locked_manager`).
+    manager: Arc<Mutex<Option<ActionQueueManager>>>,
     update_tracker: Arc<RwLock<StateUpdateTracker>>,
     sequences: Arc<RwLock<SequenceTracker>>,
     /// Serialises broadcast_state calls so concurrent dispatches can't interleave
     /// the (read prev → compute delta → emit → record new prev) sequence and
-    /// produce stale deltas computed against an outdated baseline.
+    /// produce stale deltas computed against an outdated baseline. Acquired
+    /// *before* `manager` wherever both are held, to keep a consistent lock order.
     broadcast_lock: Arc<Mutex<()>>,
 }
 
@@ -78,10 +85,6 @@ impl<R: Runtime> Zubridge<R> {
         &self.deltas
     }
 
-    pub fn thunks(&self) -> &Arc<RwLock<ThunkRegistry>> {
-        &self.thunks
-    }
-
     pub fn update_tracker(&self) -> &Arc<RwLock<StateUpdateTracker>> {
         &self.update_tracker
     }
@@ -92,6 +95,24 @@ impl<R: Runtime> Zubridge<R> {
             .try_state::<StateManagerHandle>()
             .map(|s| s.inner().clone())
             .ok_or(crate::Error::StateManagerMissing)
+    }
+
+    /// Lock the orchestrator, lazily constructing it on first use from the
+    /// registered state-manager handle (a clone of the same `Arc<Mutex<dyn
+    /// StateManager>>` that `state_handle` reads, so dispatches and reads see
+    /// the same canonical state). Errors if no state manager is registered.
+    fn locked_manager(
+        &self,
+    ) -> crate::Result<std::sync::MutexGuard<'_, Option<ActionQueueManager>>> {
+        let mut guard = self
+            .manager
+            .lock()
+            .map_err(|e| crate::Error::StateError(e.to_string()))?;
+        if guard.is_none() {
+            let handle = self.state_handle()?;
+            *guard = Some(ActionQueueManager::with_state_handle(handle));
+        }
+        Ok(guard)
     }
 
     /// Read the current state from the state manager.
@@ -115,36 +136,55 @@ impl<R: Runtime> Zubridge<R> {
         }
     }
 
-    /// Dispatch a single action and broadcast the resulting state. The
-    /// broadcast lock is acquired *before* the state-manager dispatch so the
-    /// state we read is always the state we broadcast — without that, two
-    /// concurrent dispatches A → state_A and (A → A→B) → state_AB could
-    /// interleave (B's broadcast wins the lock first, records state_AB; A's
-    /// broadcast then emits state_A as a delta against state_AB and records
-    /// state_A as the new baseline, silently undoing B's changes).
+    /// Dispatch a single action through the scheduler and broadcast the
+    /// resulting state.
+    ///
+    /// The action is routed through [`ActionQueueManager`], which decides
+    /// whether it can execute immediately or must be queued behind an active
+    /// thunk (priority + concurrency control). On immediate execution the new
+    /// state is broadcast here; if the action is queued, `Ok(None)` comes back
+    /// and the state update is emitted later when the blocking thunk completes
+    /// and the queue drains (see [`complete_thunk`]). The renderer tolerates
+    /// this — its dispatch resolves on the `invoke` returning, not on a
+    /// state-update arriving.
+    ///
+    /// `broadcast_lock` is acquired *before* dispatch so the (compute delta →
+    /// emit → record baseline) sequence can't interleave across concurrent
+    /// dispatches and stale-base a delta. The `manager` lock is acquired after
+    /// it (consistent order) and held across the broadcast so no other dispatch
+    /// can reorder its broadcast ahead of ours.
     pub fn dispatch_action(&self, action: ZubridgeAction) -> crate::Result<String> {
         let action_id = action
             .id
             .clone()
             .unwrap_or_else(|| Uuid::new_v4().to_string());
+        let thunk_id = action.thunk_parent_id.clone();
+        let source_label = action.source_label.clone().unwrap_or_default();
+
+        // Stamp the id we'll report so the broadcast source and return value agree.
+        let mut action = action;
+        if action.id.is_none() {
+            action.id = Some(action_id.clone());
+        }
 
         let _broadcast_guard = self
             .broadcast_lock
             .lock()
             .map_err(|e| crate::Error::StateError(e.to_string()))?;
+        let mut guard = self.locked_manager()?;
+        let dispatched = guard
+            .as_mut()
+            .expect("locked_manager initialises the manager")
+            .dispatch(action, source_label)?;
 
-        let new_state = state_manager::dispatch(&self.state_handle()?, action.to_legacy_json())
-            .map_err(|e| crate::Error::ActionProcessing {
+        if let Some(new_state) = dispatched {
+            let source = UpdateSource {
                 action_id: Some(action_id.clone()),
-                message: e.to_string(),
-            })?;
+                thunk_id,
+            };
+            self.broadcast_state_locked(new_state, Some(source))?;
+        }
 
-        let source = UpdateSource {
-            action_id: Some(action_id.clone()),
-            thunk_id: action.thunk_parent_id.clone(),
-        };
-
-        self.broadcast_state_locked(new_state, Some(source))?;
         Ok(action_id)
     }
 
@@ -183,11 +223,14 @@ impl<R: Runtime> Zubridge<R> {
             .broadcast_lock
             .lock()
             .map_err(|e| crate::Error::StateError(e.to_string()))?;
+        let mut guard = self.locked_manager()?;
+        let manager = guard
+            .as_mut()
+            .expect("locked_manager initialises the manager");
 
         let mut acked = Vec::with_capacity(actions.len());
-        let handle = self.state_handle()?;
-        let mut last_action_id: Option<String> = None;
-        let mut last_thunk_id: Option<String> = None;
+        let mut last_state: Option<JsonValue> = None;
+        let mut last_source: Option<UpdateSource> = None;
         let mut failed: Option<BatchFailure> = None;
 
         for action in actions {
@@ -195,12 +238,24 @@ impl<R: Runtime> Zubridge<R> {
                 .id
                 .clone()
                 .unwrap_or_else(|| Uuid::new_v4().to_string());
-            match state_manager::dispatch(&handle, action.to_legacy_json()) {
-                Ok(_) => {
-                    last_action_id = Some(action_id.clone());
-                    last_thunk_id = action.thunk_parent_id.clone();
+            let thunk_id = action.thunk_parent_id.clone();
+            let source_label = action.source_label.clone().unwrap_or_default();
+            let mut action = action;
+            if action.id.is_none() {
+                action.id = Some(action_id.clone());
+            }
+            match manager.dispatch(action, source_label) {
+                Ok(Some(state)) => {
+                    last_state = Some(state);
+                    last_source = Some(UpdateSource {
+                        action_id: Some(action_id.clone()),
+                        thunk_id,
+                    });
                     acked.push(action_id);
                 }
+                // Queued behind an active thunk: still acked (it's accepted into
+                // the queue); its state update is emitted on queue drain.
+                Ok(None) => acked.push(action_id),
                 Err(e) => {
                     failed = Some(BatchFailure {
                         action_id,
@@ -211,16 +266,11 @@ impl<R: Runtime> Zubridge<R> {
             }
         }
 
-        // Broadcast even when the loop bailed early so the renderer's replica
-        // catches up to whatever actions did commit before the error. Skipped
-        // only when nothing committed (acked is empty).
-        if !acked.is_empty() {
-            let new_state = state_manager::read_state(&handle)?;
-            let source = UpdateSource {
-                action_id: last_action_id,
-                thunk_id: last_thunk_id,
-            };
-            self.broadcast_state_locked(new_state, Some(source))?;
+        // Emit one coalesced broadcast of the last immediately-executed state.
+        // (Queued actions broadcast individually when the thunk drains.) Skipped
+        // when nothing executed immediately.
+        if let Some(new_state) = last_state {
+            self.broadcast_state_locked(new_state, last_source)?;
         }
 
         Ok(BatchDispatchResult {
@@ -454,27 +504,22 @@ impl<R: Runtime> Zubridge<R> {
         bypass_access_control: bool,
         immediate: bool,
     ) -> crate::Result<()> {
-        let mut registry = self
-            .thunks
-            .write()
-            .map_err(|e| crate::Error::ThunkRegistration {
-                thunk_id: thunk_id.clone(),
-                message: e.to_string(),
-            })?;
-        registry
-            .register(
-                thunk_id.clone(),
-                parent_id,
-                source_label,
-                keys,
-                bypass_access_control,
-                immediate,
-            )
-            .map_err(|message| crate::Error::ThunkRegistration {
-                thunk_id: thunk_id.clone(),
-                message,
-            })?;
-        let _ = registry.execute_thunk(&thunk_id);
+        let mut guard = self.locked_manager()?;
+        let manager = guard
+            .as_mut()
+            .expect("locked_manager initialises the manager");
+        manager.register_thunk(
+            thunk_id.clone(),
+            parent_id,
+            source_label,
+            keys,
+            bypass_access_control,
+            immediate,
+        )?;
+        // Transition straight to Executing/root, preserving the prior behaviour
+        // where registration also activates the thunk (so subsequent non-thunk
+        // actions queue behind it until completion).
+        let _ = manager.execute_thunk(&thunk_id);
         Ok(())
     }
 
@@ -484,14 +529,22 @@ impl<R: Runtime> Zubridge<R> {
         source_label: &str,
         error: Option<String>,
     ) -> crate::Result<()> {
-        let mut registry = self.thunks.write().map_err(|e| crate::Error::ThunkRegistration {
-            thunk_id: thunk_id.to_string(),
-            message: e.to_string(),
-        })?;
+        // Completing a thunk drains any actions queued behind it; each drained
+        // state must be broadcast, so acquire `broadcast_lock` first (consistent
+        // order: broadcast_lock → manager).
+        let _broadcast_guard = self
+            .broadcast_lock
+            .lock()
+            .map_err(|e| crate::Error::StateError(e.to_string()))?;
+        let mut guard = self.locked_manager()?;
+        let manager = guard
+            .as_mut()
+            .expect("locked_manager initialises the manager");
 
         // Verify the caller owns this thunk. Without this, any webview could
         // complete another window's in-flight thunk by id.
-        let owner_label = registry
+        let owner_label = manager
+            .thunk_manager()
             .get(thunk_id)
             .ok_or_else(|| crate::Error::ThunkNotFound {
                 thunk_id: thunk_id.to_string(),
@@ -501,26 +554,23 @@ impl<R: Runtime> Zubridge<R> {
         if owner_label != source_label {
             return Err(crate::Error::ThunkRegistration {
                 thunk_id: thunk_id.to_string(),
-                message: format!(
-                    "thunk {thunk_id} is owned by {owner_label}, not {source_label}"
-                ),
+                message: format!("thunk {thunk_id} is owned by {owner_label}, not {source_label}"),
             });
         }
 
-        registry
-            .complete(thunk_id, error)
-            .map_err(|_| crate::Error::ThunkNotFound {
-                thunk_id: thunk_id.to_string(),
-            })?;
+        // Complete + drain. Without broadcasting the drained states the queued
+        // actions mutate canonical state but never reach renderers (desync +
+        // renderer thunk safety-timeout).
+        let (_events, drained_states) = manager.on_thunk_complete(thunk_id, error)?;
+        for state in drained_states {
+            self.broadcast_state_locked(state, None)?;
+        }
         Ok(())
     }
 
     /// Register a state manager at runtime (used when the plugin is initialised
     /// without one).
-    pub fn register_state_manager<S: StateManager>(
-        &self,
-        state_manager: S,
-    ) -> crate::Result<()> {
+    pub fn register_state_manager<S: StateManager>(&self, state_manager: S) -> crate::Result<()> {
         let handle = state_manager::new_handle(state_manager);
         self.app.manage(handle);
         Ok(())
@@ -547,8 +597,10 @@ impl<R: Runtime> Zubridge<R> {
         if let Ok(mut sequences) = self.sequences.write() {
             sequences.forget(label);
         }
-        if let Ok(mut thunks) = self.thunks.write() {
-            thunks.drop_label(label);
+        if let Ok(mut guard) = self.manager.lock() {
+            if let Some(manager) = guard.as_mut() {
+                manager.thunk_manager_mut().drop_label(label);
+            }
         }
     }
 

--- a/packages/tauri-plugin/src/desktop.rs
+++ b/packages/tauri-plugin/src/desktop.rs
@@ -151,8 +151,9 @@ impl<R: Runtime> Zubridge<R> {
     /// `broadcast_lock` is acquired *before* dispatch so the (compute delta →
     /// emit → record baseline) sequence can't interleave across concurrent
     /// dispatches and stale-base a delta. The `manager` lock is acquired after
-    /// it (consistent order) and held across the broadcast so no other dispatch
-    /// can reorder its broadcast ahead of ours.
+    /// it (consistent order) and dropped *before* the broadcast — `broadcast_lock`
+    /// alone serialises the broadcast sequence, so holding `manager` across the
+    /// per-webview emit loop would only block unrelated `register_thunk` calls.
     pub fn dispatch_action(&self, action: ZubridgeAction) -> crate::Result<String> {
         let action_id = action
             .id
@@ -171,11 +172,13 @@ impl<R: Runtime> Zubridge<R> {
             .broadcast_lock
             .lock()
             .map_err(|e| crate::Error::StateError(e.to_string()))?;
-        let mut guard = self.locked_manager()?;
-        let dispatched = guard
-            .as_mut()
-            .expect("locked_manager initialises the manager")
-            .dispatch(action, source_label)?;
+        let dispatched = {
+            let mut guard = self.locked_manager()?;
+            guard
+                .as_mut()
+                .expect("locked_manager initialises the manager")
+                .dispatch(action, source_label)?
+        };
 
         if let Some(new_state) = dispatched {
             let source = UpdateSource {
@@ -223,45 +226,51 @@ impl<R: Runtime> Zubridge<R> {
             .broadcast_lock
             .lock()
             .map_err(|e| crate::Error::StateError(e.to_string()))?;
-        let mut guard = self.locked_manager()?;
-        let manager = guard
-            .as_mut()
-            .expect("locked_manager initialises the manager");
 
         let mut acked = Vec::with_capacity(actions.len());
         let mut last_state: Option<JsonValue> = None;
         let mut last_source: Option<UpdateSource> = None;
         let mut failed: Option<BatchFailure> = None;
 
-        for action in actions {
-            let action_id = action
-                .id
-                .clone()
-                .unwrap_or_else(|| Uuid::new_v4().to_string());
-            let thunk_id = action.thunk_parent_id.clone();
-            let source_label = action.source_label.clone().unwrap_or_default();
-            let mut action = action;
-            if action.id.is_none() {
-                action.id = Some(action_id.clone());
-            }
-            match manager.dispatch(action, source_label) {
-                Ok(Some(state)) => {
-                    last_state = Some(state);
-                    last_source = Some(UpdateSource {
-                        action_id: Some(action_id.clone()),
-                        thunk_id,
-                    });
-                    acked.push(action_id);
+        // Scope the manager guard to the dispatch loop so it is released before
+        // the broadcast below — `broadcast_lock` already serialises the emit,
+        // and holding `manager` across it would needlessly block `register_thunk`.
+        {
+            let mut guard = self.locked_manager()?;
+            let manager = guard
+                .as_mut()
+                .expect("locked_manager initialises the manager");
+
+            for action in actions {
+                let action_id = action
+                    .id
+                    .clone()
+                    .unwrap_or_else(|| Uuid::new_v4().to_string());
+                let thunk_id = action.thunk_parent_id.clone();
+                let source_label = action.source_label.clone().unwrap_or_default();
+                let mut action = action;
+                if action.id.is_none() {
+                    action.id = Some(action_id.clone());
                 }
-                // Queued behind an active thunk: still acked (it's accepted into
-                // the queue); its state update is emitted on queue drain.
-                Ok(None) => acked.push(action_id),
-                Err(e) => {
-                    failed = Some(BatchFailure {
-                        action_id,
-                        message: e.to_string(),
-                    });
-                    break;
+                match manager.dispatch(action, source_label) {
+                    Ok(Some(state)) => {
+                        last_state = Some(state);
+                        last_source = Some(UpdateSource {
+                            action_id: Some(action_id.clone()),
+                            thunk_id,
+                        });
+                        acked.push(action_id);
+                    }
+                    // Queued behind an active thunk: still acked (it's accepted into
+                    // the queue); its state update is emitted on queue drain.
+                    Ok(None) => acked.push(action_id),
+                    Err(e) => {
+                        failed = Some(BatchFailure {
+                            action_id,
+                            message: e.to_string(),
+                        });
+                        break;
+                    }
                 }
             }
         }
@@ -536,34 +545,48 @@ impl<R: Runtime> Zubridge<R> {
             .broadcast_lock
             .lock()
             .map_err(|e| crate::Error::StateError(e.to_string()))?;
-        let mut guard = self.locked_manager()?;
-        let manager = guard
-            .as_mut()
-            .expect("locked_manager initialises the manager");
 
-        // Verify the caller owns this thunk. Without this, any webview could
-        // complete another window's in-flight thunk by id.
-        let owner_label = manager
-            .thunk_manager()
-            .get(thunk_id)
-            .ok_or_else(|| crate::Error::ThunkNotFound {
-                thunk_id: thunk_id.to_string(),
-            })?
-            .source_label
-            .clone();
-        if owner_label != source_label {
-            return Err(crate::Error::ThunkRegistration {
-                thunk_id: thunk_id.to_string(),
-                message: format!("thunk {thunk_id} is owned by {owner_label}, not {source_label}"),
-            });
-        }
+        // Complete + drain under the manager guard, then release it before the
+        // broadcast loop: `broadcast_lock` already serialises the emit, so
+        // holding `manager` across it would only block unrelated `register_thunk`.
+        let drained_states = {
+            let mut guard = self.locked_manager()?;
+            let manager = guard
+                .as_mut()
+                .expect("locked_manager initialises the manager");
 
-        // Complete + drain. Without broadcasting the drained states the queued
-        // actions mutate canonical state but never reach renderers (desync +
-        // renderer thunk safety-timeout).
-        let (_events, drained_states) = manager.on_thunk_complete(thunk_id, error)?;
-        for state in drained_states {
-            self.broadcast_state_locked(state, None)?;
+            // Verify the caller owns this thunk. Without this, any webview could
+            // complete another window's in-flight thunk by id.
+            let owner_label = manager
+                .thunk_manager()
+                .get(thunk_id)
+                .ok_or_else(|| crate::Error::ThunkNotFound {
+                    thunk_id: thunk_id.to_string(),
+                })?
+                .source_label
+                .clone();
+            if owner_label != source_label {
+                return Err(crate::Error::ThunkRegistration {
+                    thunk_id: thunk_id.to_string(),
+                    message: format!(
+                        "thunk {thunk_id} is owned by {owner_label}, not {source_label}"
+                    ),
+                });
+            }
+
+            // Without broadcasting the drained states the queued actions mutate
+            // canonical state but never reach renderers (desync + renderer thunk
+            // safety-timeout).
+            let (_events, drained_states) = manager.on_thunk_complete(thunk_id, error)?;
+            drained_states
+        };
+
+        for drained in drained_states {
+            let source = UpdateSource {
+                action_id: drained.action_id,
+                thunk_id: drained.thunk_id,
+            };
+            self.broadcast_state_locked(drained.state, Some(source))?;
         }
         Ok(())
     }
@@ -585,6 +608,14 @@ impl<R: Runtime> Zubridge<R> {
     /// manage webviews outside the standard close flow (e.g. embedded webview
     /// pools) can release per-label state explicitly.
     pub fn forget_label(&self, label: &str) {
+        // Dropping this label's thunk can unblock actions that were queued
+        // behind it; those must be drained and broadcast to the surviving
+        // windows, else they stay stuck in the scheduler forever (mirrors
+        // `complete_thunk`). Hold `broadcast_lock` across the drain + broadcast
+        // (consistent order: broadcast_lock → manager). Best-effort throughout:
+        // a poisoned lock simply skips the affected step.
+        let _broadcast_guard = self.broadcast_lock.lock().ok();
+
         if let Ok(mut subs) = self.subscriptions.write() {
             subs.drop_label(label);
         }
@@ -597,9 +628,33 @@ impl<R: Runtime> Zubridge<R> {
         if let Ok(mut sequences) = self.sequences.write() {
             sequences.forget(label);
         }
-        if let Ok(mut guard) = self.manager.lock() {
-            if let Some(manager) = guard.as_mut() {
-                manager.thunk_manager_mut().drop_label(label);
+
+        // Drop the label's thunks and drain behind it under the manager guard,
+        // then release it before broadcasting (same reasoning as complete_thunk).
+        let drained_states = {
+            let Ok(mut guard) = self.manager.lock() else {
+                return;
+            };
+            // Manager never built (no dispatch/thunk yet) → nothing was queued.
+            let Some(manager) = guard.as_mut() else {
+                return;
+            };
+            match manager.on_label_forgotten(label) {
+                Ok(states) => states,
+                Err(err) => {
+                    log::warn!("zubridge: draining queue after forget failed: {err}");
+                    return;
+                }
+            }
+        };
+
+        for drained in drained_states {
+            let source = UpdateSource {
+                action_id: drained.action_id,
+                thunk_id: drained.thunk_id,
+            };
+            if let Err(err) = self.broadcast_state_locked(drained.state, Some(source)) {
+                log::warn!("zubridge: post-forget broadcast failed: {err}");
             }
         }
     }


### PR DESCRIPTION
**PR 1 of 2** for Tauri v2 backend thunks. This is the prerequisite: wire the ported action scheduler into the plugin so thunks actually coordinate. PR 2 adds the backend-thunk commands on top.

## Problem

`Zubridge::dispatch_action` was a direct read→apply→broadcast that never consulted the core scheduler. `thunk_parent_id` was only broadcast metadata, so **no thunk on Tauri — renderer or backend — blocked or coordinated concurrent actions.** The refactor plan's "full scheduler parity to Electron v3" wasn't actually wired into the plugin (the `ThunkManager` was present for lifecycle *tracking* but unused for dispatch eligibility).

## Change

- `Zubridge<R>` now holds `Arc<Mutex<Option<ActionQueueManager>>>` (scheduler + thunk manager + state handle, unified), **lazily built on first use** from the managed state handle — so plugin construction (`lib.rs`) is unchanged. Drops the separate `ThunkRegistry` field.
- `dispatch_action` / `batch_dispatch` route through `manager.dispatch()`: immediate execution broadcasts as before; an action queued behind an active thunk returns `Ok(None)` and its update is emitted when the thunk drains. The renderer already tolerates this — it completes a dispatch on `invoke` resolving, not on a state-update arriving (`rendererThunkProcessor.ts:320`).
- `register_thunk` / `complete_thunk` delegate to the manager; **`complete_thunk` broadcasts every drained state** (otherwise queued actions mutate state invisibly → desync + renderer-thunk safety-timeout).
- Lock order: `broadcast_lock → manager`, held across dispatch+broadcast so the delta baseline can't race (preserves the existing invariant).

Drained-state broadcasts use `source: None` for now — the renderer keys ack/ordering off per-broadcast `seq`/`update_id`, not `source`. Provenance thread-through is a small follow-up.

## Verification

- **70 `zubridge-core` tests pass** (scheduler/thunk/blocking logic unchanged).
- **Tauri E2E green** (zustand-basic):
  - `basic-sync` (4 specs) — **no regression** on plain dispatch + bidirectional window sync.
  - **new `renderer-thunk` spec** — renderer thunk doubles + propagates **through the new scheduler**, and a post-thunk increment confirms `complete_thunk` drained and unblocked the queue.
- Plugin compiles clean; no clippy warnings in changed files. (Note: CI gates Rust via `cargo test -p zubridge-core` only.)

## Not in scope

Migrating Electron to this orchestrator (P6) and `source`-provenance on drained broadcasts (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires the `ActionQueueManager` (scheduler + thunk lifecycle + state handle) into the Tauri plugin so that all action dispatch, thunk registration/completion, and webview teardown route through a unified orchestrator rather than the old direct read→apply→broadcast path. The `ThunkRegistry` field is replaced by an `Arc<Mutex<Option<ActionQueueManager>>>` that is lazily built on first use, preserving unchanged plugin construction in `lib.rs`.

- `dispatch_action` / `batch_dispatch` now route through `manager.dispatch()`, returning `Ok(None)` for queued actions and broadcasting only immediately-executed states; drained states are emitted individually per action when the blocking thunk completes via `complete_thunk`.
- `forget_label` calls the new `on_label_forgotten` method, which drops the window's thunks and drains any queued actions behind them, preventing the previous silent indefinite queue stall on window destruction.
- `DrainedState` threads action provenance (`action_id`, `thunk_id`) through the drain path so drained broadcasts carry proper `UpdateSource` metadata instead of `None`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the scheduler wiring is correct, lock ordering is consistent throughout, and all three previously-flagged concerns (teardown drain, source provenance on drained states, manager-guard scope during broadcast) are fully resolved.

Lock ordering (broadcast_lock → manager) is consistently enforced across every call site. The manager guard is scoped tightly and released before every broadcast loop. forget_label now properly drains and broadcasts queued actions when a window is destroyed. DrainedState threads action_id and thunk_id through the drain path so drained broadcasts carry correct UpdateSource metadata. 70 core unit tests and the new E2E renderer-thunk spec all pass.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/orchestration/mod.rs | Adds DrainedState struct for provenance tagging, changes drain_queue return type to Vec<DrainedState>, adds on_label_forgotten for teardown drain, and extends on_thunk_complete signature. All 70 core tests pass. |
| packages/tauri-plugin/src/desktop.rs | Replaces ThunkRegistry with ActionQueueManager (lazily constructed), wires all dispatch/thunk/teardown paths through the orchestrator with consistent broadcast_lock → manager lock order. Drained states are individually broadcast after thunk completion and window teardown. |
| packages/tauri-plugin/src/core/mod.rs | Adds ActionQueueManager and DrainedState to re-exports; removes ThunkRegistry. |
| apps/tauri/e2e/test/specs/renderer-thunk.spec.ts | New E2E spec verifying renderer-thunk path through the scheduler end-to-end, including post-thunk unblock verification. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(core): don&#39;t silently discard drain\_..."](https://github.com/goosewobbler/zubridge/commit/5b0b59acb6915c435479fd6728c61ffe4db13951) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39834390)</sub>

<!-- /greptile_comment -->