### PR TITLE
feat(tauri-e2e): add Rust backend thunks (main-process thunk parity)

### DIFF
--- a/apps/tauri/e2e/src-tauri/src/lib.rs
+++ b/apps/tauri/e2e/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod commands;
 pub mod features;
 pub mod modes;
 pub mod store;
+pub mod thunks;
 pub mod tray;
 pub mod window;
 
@@ -101,6 +102,8 @@ pub fn run() {
             commands::create_runtime_window,
             commands::close_current_window,
             commands::is_main_window,
+            thunks::execute_main_thunk,
+            thunks::execute_main_thunk_slow,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/tauri/e2e/src-tauri/src/thunks.rs
+++ b/apps/tauri/e2e/src-tauri/src/thunks.rs
@@ -1,0 +1,176 @@
+//! Backend (Rust) thunks paralleling Electron's main-process thunk
+//! (`apps/electron/e2e/src/main/index.ts` EXECUTE_MAIN_THUNK / _SLOW).
+//!
+//! A backend thunk reads the counter, then dispatches a DOUBLE -> DOUBLE ->
+//! HALVE sequence with delays *between* dispatches (net N -> 2N), coordinated
+//! via the core thunk-lifecycle API. Because the plugin routes dispatch through
+//! the action scheduler, registering the thunk blocks concurrent non-thunk
+//! actions (e.g. increments from a webview) until the thunk completes — the
+//! same coordination Electron's main thunks get.
+//!
+//! "Main process thunks" in Electron are JS thunks dispatched from the Node
+//! main process. Tauri's backend is Rust with no JS runtime, so the equivalent
+//! is authored in Rust here; the *symmetry* (same code front and back) does not
+//! carry over, but the backend-originated, cross-window-propagating behaviour
+//! does.
+
+use std::time::Duration;
+
+use serde::Serialize;
+use serde_json::Value;
+use tauri::{AppHandle, Runtime};
+use tauri_plugin_zubridge::{ZubridgeAction, ZubridgeExt};
+use uuid::Uuid;
+
+/// Synthetic source label that owns backend thunks. Distinct from any real
+/// webview label (`main`, `secondary`, `runtime_*`) so window-close cleanup
+/// (`forget_label`) never drops it mid-flight.
+const BACKEND_LABEL: &str = "__backend";
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MainThunkResult {
+    pub success: bool,
+    pub result: i32,
+}
+
+/// Build a backend-sourced action tagged with the in-flight thunk id, so the
+/// scheduler treats it as belonging to the active root thunk (executes
+/// immediately) and the broadcast attributes the update to the thunk.
+fn backend_action(action_type: &str, thunk_id: &str) -> ZubridgeAction {
+    ZubridgeAction {
+        id: None,
+        action_type: action_type.to_string(),
+        payload: None,
+        source_label: Some(BACKEND_LABEL.to_string()),
+        thunk_parent_id: Some(thunk_id.to_string()),
+        immediate: None,
+        keys: None,
+        bypass_access_control: None,
+        starts_thunk: None,
+        ends_thunk: None,
+    }
+}
+
+/// Read the current counter from plugin state (0 if absent, matching Electron's
+/// `currentState.counter || 0`).
+fn read_counter<R: Runtime>(app: &AppHandle<R>) -> Result<i32, String> {
+    let state = app
+        .zubridge()
+        .get_initial_state()
+        .map_err(|e| e.to_string())?;
+    Ok(state.get("counter").and_then(Value::as_i64).unwrap_or(0) as i32)
+}
+
+/// Register a thunk, run the DOUBLE/DOUBLE/HALVE sequence, then complete it.
+/// `slow` selects the `:SLOW` action types and the longer inter-step delay.
+async fn run_double_thunk<R: Runtime>(
+    app: AppHandle<R>,
+    slow: bool,
+) -> Result<MainThunkResult, String> {
+    let (double, halve, delay) = if slow {
+        (
+            "COUNTER:DOUBLE:SLOW",
+            "COUNTER:HALVE:SLOW",
+            Duration::from_millis(1000),
+        )
+    } else {
+        ("COUNTER:DOUBLE", "COUNTER:HALVE", Duration::from_millis(100))
+    };
+
+    // Unique id per invocation so concurrent triggers never collide on register.
+    let thunk_id = Uuid::new_v4().to_string();
+    app.zubridge()
+        .register_thunk(
+            thunk_id.clone(),
+            None,
+            BACKEND_LABEL.to_string(),
+            None,
+            false,
+            false,
+        )
+        .map_err(|e| e.to_string())?;
+
+    // Run the sequence; complete the thunk on *every* exit path, otherwise the
+    // registry leaks the record and the scheduler stays blocked forever.
+    let outcome = drive_sequence(&app, &thunk_id, double, halve, delay).await;
+    let error = outcome.as_ref().err().cloned();
+    if let Err(e) = app
+        .zubridge()
+        .complete_thunk(&thunk_id, BACKEND_LABEL, error)
+    {
+        eprintln!("[BackendThunk] complete_thunk({thunk_id}) failed: {e}");
+    }
+
+    outcome.map(|result| MainThunkResult {
+        success: true,
+        result,
+    })
+}
+
+/// read -> DOUBLE -> sleep -> DOUBLE -> sleep -> HALVE -> sleep -> read.
+/// Each dispatch is a separate `dispatch_action` (which takes + releases the
+/// plugin's broadcast lock internally); the `sleep` happens *between*
+/// dispatches with no lock held.
+async fn drive_sequence<R: Runtime>(
+    app: &AppHandle<R>,
+    thunk_id: &str,
+    double: &str,
+    halve: &str,
+    delay: Duration,
+) -> Result<i32, String> {
+    let _start = read_counter(app)?; // parity with Electron's getState() at the top
+
+    app.zubridge()
+        .dispatch_action(backend_action(double, thunk_id))
+        .map_err(|e| e.to_string())?;
+    tokio::time::sleep(delay).await;
+
+    app.zubridge()
+        .dispatch_action(backend_action(double, thunk_id))
+        .map_err(|e| e.to_string())?;
+    tokio::time::sleep(delay).await;
+
+    app.zubridge()
+        .dispatch_action(backend_action(halve, thunk_id))
+        .map_err(|e| e.to_string())?;
+    tokio::time::sleep(delay).await;
+
+    read_counter(app)
+}
+
+#[tauri::command]
+pub async fn execute_main_thunk<R: Runtime>(app: AppHandle<R>) -> Result<MainThunkResult, String> {
+    run_double_thunk(app, false).await
+}
+
+#[tauri::command]
+pub async fn execute_main_thunk_slow<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<MainThunkResult, String> {
+    run_double_thunk(app, true).await
+}
+
+#[cfg(test)]
+mod tests {
+    // Pure model of the DOUBLE/DOUBLE/HALVE net effect, mirroring
+    // `features::counter::{double, halve}`. The async command path is covered
+    // by the Tauri E2E suite (`test/specs/backend-thunk.spec.ts`).
+    fn double(x: i32) -> i32 {
+        x.saturating_mul(2)
+    }
+    fn halve(x: i32) -> i32 {
+        ((x as f64) / 2.0).round() as i32
+    }
+    fn final_counter_from(start: i32) -> i32 {
+        halve(double(double(start)))
+    }
+
+    #[test]
+    fn net_effect_is_a_double() {
+        assert_eq!(final_counter_from(5), 10);
+        assert_eq!(final_counter_from(3), 6);
+        assert_eq!(final_counter_from(0), 0);
+        assert_eq!(final_counter_from(-4), -8);
+    }
+}

--- a/apps/tauri/e2e/src-tauri/src/thunks.rs
+++ b/apps/tauri/e2e/src-tauri/src/thunks.rs
@@ -108,10 +108,12 @@ async fn run_double_thunk<R: Runtime>(
     })
 }
 
-/// read -> DOUBLE -> sleep -> DOUBLE -> sleep -> HALVE -> sleep -> read.
+/// DOUBLE -> sleep -> DOUBLE -> sleep -> HALVE -> read.
 /// Each dispatch is a separate `dispatch_action` (which takes + releases the
 /// plugin's broadcast lock internally); the `sleep` happens *between*
-/// dispatches with no lock held.
+/// dispatches with no lock held. `dispatch_action` commits state synchronously,
+/// so the closing `read_counter` sees the post-HALVE value with no trailing
+/// delay.
 async fn drive_sequence<R: Runtime>(
     app: &AppHandle<R>,
     thunk_id: &str,
@@ -119,7 +121,9 @@ async fn drive_sequence<R: Runtime>(
     halve: &str,
     delay: Duration,
 ) -> Result<i32, String> {
-    let _start = read_counter(app)?; // parity with Electron's getState() at the top
+    // Electron's main thunk reads getState() here; the net effect is
+    // deterministic, so the backend thunk skips the live read (and its extra
+    // lock cycle + failure path) and just returns the post-sequence value below.
 
     app.zubridge()
         .dispatch_action(backend_action(double, thunk_id))
@@ -134,7 +138,6 @@ async fn drive_sequence<R: Runtime>(
     app.zubridge()
         .dispatch_action(backend_action(halve, thunk_id))
         .map_err(|e| e.to_string())?;
-    tokio::time::sleep(delay).await;
 
     read_counter(app)
 }

--- a/apps/tauri/e2e/src/renderer/main.tsx
+++ b/apps/tauri/e2e/src/renderer/main.tsx
@@ -67,6 +67,13 @@ function AppBootstrap() {
             handler: (event: E) => void,
           ) => Promise<UnlistenFn>,
         });
+        // Expose the backend-thunk hooks the shared UI's "Main Thunk" buttons
+        // call. On Tauri these invoke Rust commands that drive a backend thunk;
+        // Electron exposes the equivalent from its Node main process via preload.
+        window.counter = {
+          executeMainThunk: () => invoke('execute_main_thunk'),
+          executeMainThunkSlow: () => invoke('execute_main_thunk_slow'),
+        };
         if (!cancelled) setBridgeReady(true);
       } catch (error) {
         debug('ui:error', `Bridge initialization failed: ${error}`);

--- a/apps/tauri/e2e/test/specs/backend-thunk.spec.ts
+++ b/apps/tauri/e2e/test/specs/backend-thunk.spec.ts
@@ -1,0 +1,74 @@
+import { browser } from '@wdio/globals';
+import { beforeEach, describe, it } from 'mocha';
+import { getCounterValue, resetCounter, waitForCounterValue } from '../utils/counter.js';
+import { setupTestEnvironment, switchToWindow } from '../utils/window.js';
+
+// Exercises the Rust *backend* thunk (execute_main_thunk / _slow): a thunk
+// authored in Rust, registered + driven through the core scheduler, dispatching
+// DOUBLE/DOUBLE/HALVE (net x2) with updates propagating to every webview.
+describe('Tauri Backend (Main) Thunk', () => {
+  beforeEach(async () => {
+    await setupTestEnvironment();
+    await resetCounter();
+  });
+
+  const seedTo = async (value: number) => {
+    const inc = await browser.$('[aria-label="Increment counter"]');
+    for (let i = 0; i < value; i++) {
+      await inc.click();
+    }
+    await waitForCounterValue(value);
+  };
+
+  it('doubles the counter via the backend thunk and propagates to the secondary window', async () => {
+    await switchToWindow('main');
+    await seedTo(5);
+
+    const btn = await browser.$('[aria-label="Double counter using main process thunk"]');
+    await btn.click();
+    // 5 -> 10 -> 20 -> 10. The final value (10) also appears after the first
+    // DOUBLE, so wait for it then let the thunk settle (it must not still be
+    // running when the next test's resetCounter runs).
+    await waitForCounterValue(10);
+    await browser.pause(600);
+    const settled = await getCounterValue();
+    if (settled !== 10) {
+      throw new Error(`expected backend thunk to settle the counter at 10, got ${settled}`);
+    }
+
+    await switchToWindow('secondary');
+    await waitForCounterValue(10);
+  });
+
+  it('blocks concurrent actions while a slow backend thunk runs, then drains them', async () => {
+    await switchToWindow('main');
+    await seedTo(5);
+
+    // Kick off the slow backend thunk (registers a thunk -> active root).
+    const slowBtn = await browser.$('[aria-label="Double counter using slow main process thunk"]');
+    await slowBtn.click();
+
+    // While it runs, fire two increments from the other window. With the
+    // scheduler wired they queue behind the thunk and drain only after it
+    // completes, so the deterministic result is double(5)=10 then +2 = 12.
+    // Without blocking the increments would interleave with the DOUBLE/HALVE
+    // steps and the settled value would vary.
+    await switchToWindow('secondary');
+    const inc = await browser.$('[aria-label="Increment counter"]');
+    await inc.click();
+    await inc.click();
+
+    // Wait for the thunk + drained increments to settle, then assert it stays
+    // put (guards against a transient pass-through of 12).
+    await switchToWindow('main');
+    await waitForCounterValue(12, 15000);
+    await browser.pause(500);
+    const settled = await getCounterValue();
+    if (settled !== 12) {
+      throw new Error(`expected counter to settle at 12, got ${settled}`);
+    }
+
+    await switchToWindow('secondary');
+    await waitForCounterValue(12);
+  });
+});

--- a/apps/tauri/e2e/test/specs/backend-thunk.spec.ts
+++ b/apps/tauri/e2e/test/specs/backend-thunk.spec.ts
@@ -1,6 +1,11 @@
 import { browser } from '@wdio/globals';
 import { beforeEach, describe, it } from 'mocha';
-import { getCounterValue, resetCounter, waitForCounterValue } from '../utils/counter.js';
+import {
+  getCounterValue,
+  resetCounter,
+  waitForCounterValue,
+  waitForStableCounterValue,
+} from '../utils/counter.js';
 import { setupTestEnvironment, switchToWindow } from '../utils/window.js';
 
 // Exercises the Rust *backend* thunk (execute_main_thunk / _slow): a thunk
@@ -26,15 +31,12 @@ describe('Tauri Backend (Main) Thunk', () => {
 
     const btn = await browser.$('[aria-label="Double counter using main process thunk"]');
     await btn.click();
-    // 5 -> 10 -> 20 -> 10. The final value (10) also appears after the first
-    // DOUBLE, so wait for it then let the thunk settle (it must not still be
-    // running when the next test's resetCounter runs).
-    await waitForCounterValue(10);
-    await browser.pause(600);
-    const settled = await getCounterValue();
-    if (settled !== 10) {
-      throw new Error(`expected backend thunk to settle the counter at 10, got ${settled}`);
-    }
+    // 5 -> 10 -> 20 -> 10. A net DOUBLE/DOUBLE/HALVE always passes through its
+    // final value (2N) after the first DOUBLE, so no seed makes the final unique
+    // and a plain equality wait can resolve on that intermediate. Wait for the
+    // counter to *settle* at 10 instead (it must not still be running when the
+    // next test's resetCounter runs).
+    await waitForStableCounterValue(10);
 
     await switchToWindow('secondary');
     await waitForCounterValue(10);

--- a/apps/tauri/e2e/test/utils/counter.ts
+++ b/apps/tauri/e2e/test/utils/counter.ts
@@ -20,6 +20,37 @@ export const waitForCounterValue = async (expected: number, timeoutMs = 10000): 
   throw new Error(`Timeout waiting for counter ${expected} (last seen: ${actual})`);
 };
 
+// Wait for the counter to *settle* at `expected`: it must read `expected`
+// continuously for `stableMs`. Needed when the awaited value also appears as a
+// transient mid-sequence (e.g. a DOUBLE/DOUBLE/HALVE thunk passes through its
+// final value after the first DOUBLE), where a plain equality wait can resolve
+// on the intermediate. `stableMs` must exceed the longest a non-final match is
+// held (the thunk's inter-step delay) so an intermediate can't satisfy it.
+export const waitForStableCounterValue = async (
+  expected: number,
+  stableMs = 500,
+  timeoutMs = 10000,
+): Promise<void> => {
+  const start = Date.now();
+  let stableSince: number | undefined;
+  let actual: number | undefined;
+  while (Date.now() - start < timeoutMs) {
+    actual = await getCounterValue();
+    if (actual === expected) {
+      if (stableSince === undefined) {
+        stableSince = Date.now();
+      }
+      if (Date.now() - stableSince >= stableMs) {
+        return;
+      }
+    } else {
+      stableSince = undefined;
+    }
+    await browser.pause(100);
+  }
+  throw new Error(`Timeout waiting for counter to settle at ${expected} (last seen: ${actual})`);
+};
+
 export const resetCounter = async (): Promise<void> => {
   let value = await getCounterValue();
   while (value > 0) {


### PR DESCRIPTION
**PR 2 of 2** for Tauri v2 backend thunks. **Stacked on #187** (scheduler wiring) — base is `feat/tauri-plugin-scheduler`; retarget to `main` once #187 merges.

## What

The Tauri equivalent of Electron's "main process thunk". Electron dispatches a *JS* thunk from its Node main process; Tauri's backend is **Rust with no JS runtime**, so the thunk is authored in Rust. `execute_main_thunk` / `execute_main_thunk_slow` register a thunk, read the counter, dispatch `DOUBLE → DOUBLE → HALVE` (net ×2) with delays between steps, then complete it — updates propagating to every webview.

The authoring *symmetry* of Electron main thunks (same JS front and back) can't carry to a Rust backend (tracked as a platform-difference decision in #185), but the **backend-originated, cross-window-propagating, scheduler-coordinated** behaviour does.

## How

- `apps/tauri/e2e/src-tauri/src/thunks.rs` (new) — the two async commands + a pure net-counter unit test. Reuses the tray's `ZubridgeAction` construction; each step is a separate `dispatch_action` with `tokio::sleep` *between* (never a lock across `.await`); `complete_thunk` runs on every exit path.
- `lib.rs` — register the module + commands in `generate_handler!`.
- renderer `main.tsx` — wire `window.counter` to `invoke` the commands. This re-enables the shared UI's "Main Thunk" buttons on Tauri (and composes with #186's capability gate).

## Why it needs #187

With the scheduler wired (#187), registering the backend thunk makes it an active root, so concurrent non-thunk actions **queue behind it and drain on completion**. Without #187 the buttons would still *work* but wouldn't coordinate.

## Verification

- `thunks` pure-logic unit test passes; app **typechecks** (`window.counter` wiring).
- **Tauri E2E green (3 spec files):**
  - `backend-thunk` (2): doubles + propagates; **a slow backend thunk blocks two concurrent increments from the secondary window and drains them after — deterministic 5 → 10 → 12** (the end-to-end proof of coordination).
  - `basic-sync` (4) + `renderer-thunk` (1) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces Rust backend thunks for the Tauri E2E app, completing the Tauri-side equivalent of Electron's main-process thunk. A new `thunks.rs` module implements two Tauri commands (`execute_main_thunk` / `execute_main_thunk_slow`) that register a thunk with the scheduler, dispatch a DOUBLE→DOUBLE→HALVE sequence with inter-step delays, and call `complete_thunk` on every exit path — ensuring the scheduler never deadlocks on error.

- **`thunks.rs`**: Lock-free async design with sleeps between dispatches (never across an await with a lock held); `complete_thunk` is guaranteed to fire via the surrounding `outcome` pattern regardless of error.
- **`main.tsx`**: Exposes `window.counter.executeMainThunk` / `executeMainThunkSlow` after bridge init, wiring the shared UI buttons to the Rust commands.
- **`counter.ts` / `backend-thunk.spec.ts`**: Adds `waitForStableCounterValue` (stability polling for 500 ms) to guard against the DOUBLE/DOUBLE/HALVE ambiguous intermediate, plus two new specs covering propagation and scheduler-coordinated blocking/draining.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge once stacked on #187; all exit paths call complete_thunk, the scheduler coordination is correctly designed, and the E2E suite is green.

The Rust async design is sound — locks are never held across awaits, complete_thunk fires on every exit path, and UUIDs prevent concurrent invocation collisions. The waitForStableCounterValue utility correctly handles the intermediate-value ambiguity flagged in earlier rounds. One open question is whether get_initial_state returns live state for the result field, but this does not affect counter correctness or E2E assertions.

The only open question is in thunks.rs: whether get_initial_state returns live state or a startup snapshot. All other files are straightforward.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/tauri/e2e/src-tauri/src/thunks.rs | New Rust backend thunk module: DOUBLE→DOUBLE→HALVE sequence coordinated via register_thunk/complete_thunk, with correct lock-free async design. `read_counter` calls `get_initial_state()` post-dispatch to produce the returned `result`; if that function returns a cached snapshot rather than live state, `result` would reflect the pre-thunk value. |
| apps/tauri/e2e/test/specs/backend-thunk.spec.ts | Two new E2E specs: propagation test uses `waitForStableCounterValue` to safely handle the intermediate-10 pass-through; blocking/draining test relies on window-switch latency to ensure increments arrive after `register_thunk`. Both are well-structured and CI is green. |
| apps/tauri/e2e/test/utils/counter.ts | Adds `waitForStableCounterValue` which correctly resets stability tracking when the counter deviates, guarding against the DOUBLE/DOUBLE/HALVE intermediate-value ambiguity. Default `stableMs=500` safely exceeds the fast thunk's 100 ms inter-step delay. |
| apps/tauri/e2e/src/renderer/main.tsx | Wires `window.counter.executeMainThunk` / `executeMainThunkSlow` after bridge initialization; correctly placed before the `setBridgeReady` gate so buttons are available when the UI renders. |
| apps/tauri/e2e/src-tauri/src/lib.rs | Straightforward module declaration and command handler registration for the two new thunk commands. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as Renderer (main)
    participant Rust as Rust Backend
    participant Sched as Action Scheduler
    participant S as Secondary Window

    R->>Rust: invoke execute_main_thunk
    Rust->>Sched: register_thunk(thunk_id)
    Note over Sched: Blocks non-thunk actions
    Rust->>Sched: dispatch_action DOUBLE
    Sched-->>R: 5 to 10
    Sched-->>S: 5 to 10
    Note over Rust: sleep 100ms
    Rust->>Sched: dispatch_action DOUBLE
    Sched-->>R: 10 to 20
    Sched-->>S: 10 to 20
    Note over Rust: sleep 100ms
    Rust->>Sched: dispatch_action HALVE
    Sched-->>R: 20 to 10
    Sched-->>S: 20 to 10
    Rust->>Sched: complete_thunk(thunk_id)
    Note over Sched: Drains queued actions
    Rust-->>R: MainThunkResult success
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(tauri-e2e): address backend-thunk re..."](https://github.com/goosewobbler/zubridge/commit/4a701a8763e7b2e25928cd40d50e17c48410aae8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39837275)</sub>

<!-- /greptile_comment -->