### PR TITLE
fix(electron): drop workspace: protocol runtime dep that broke npm install (#194)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: ✅ Run Typecheck
         run: pnpm run typecheck
 
+      - name: 📦 Check Publishability
+        run: pnpm run check:publishable
+
       - name: 🧪 Run Unit Tests
         run: pnpm test:unit
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "biome lint --write .",
     "check": "biome check .",
     "check:fix": "biome check --write .",
+    "check:publishable": "tsx scripts/check-publishable.ts",
     "lint:fix:unsafe": "biome check --write --unsafe .",
     "graph:e2e": "tsx ./scripts/create-task-graph.ts ./e2e-graph.png test:unit test:e2e:reducers test:e2e:handlers test:e2e:basic test:e2e:redux test:e2e:custom",
     "logs:e2e": "cat ./e2e/wdio-logs-electron-basic/wdio.log || cat ./e2e/wdio-logs-electron-handlers/wdio.log || cat ./e2e/wdio-logs-electron-reducers/wdio.log || cat ./e2e/wdio-logs-electron-redux/wdio.log || cat ./e2e/wdio-logs-electron-custom/wdio.log",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -89,6 +89,7 @@
     "@types/shelljs": "^0.10.0",
     "@vitest/coverage-v8": "^4.1.9",
     "@zubridge/types": "workspace:*",
+    "@zubridge/utils": "workspace:*",
     "immer": "^11.1.8",
     "jsdom": "^29.1.1",
     "react": "^19.2.7",
@@ -112,8 +113,6 @@
   ],
   "dependencies": {
     "@oxc-project/runtime": "^0.136.0",
-    "@types/debug": "^4.1.12",
-    "@zubridge/utils": "workspace:*",
     "dequal": "^2.0.3",
     "uuid": "^14.0.0",
     "zod": "^4.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1130,12 +1130,6 @@ importers:
       '@oxc-project/runtime':
         specifier: ^0.136.0
         version: 0.136.0
-      '@types/debug':
-        specifier: ^4.1.12
-        version: 4.1.13
-      '@zubridge/utils':
-        specifier: workspace:*
-        version: link:../utils
       dequal:
         specifier: ^2.0.3
         version: 2.0.3
@@ -1176,6 +1170,9 @@ importers:
       '@zubridge/types':
         specifier: workspace:*
         version: link:../types
+      '@zubridge/utils':
+        specifier: workspace:*
+        version: link:../utils
       immer:
         specifier: ^11.1.8
         version: 11.1.8

--- a/scripts/check-publishable.ts
+++ b/scripts/check-publishable.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+/**
+ * Publishability guard for the workspace's public packages.
+ *
+ * Reproduces the two failure modes behind issue #194, neither of which the
+ * package E2E harness (run-package-e2e.ts) can catch: it installs from local
+ * tarballs, uses pnpm (which tolerates the `workspace:` protocol), and
+ * overrides every @zubridge/* dependency to a local file.
+ *
+ *   1. Protocol lint — packs each publishable package with `pnpm pack` (the
+ *      same workspace-protocol rewrite path `pnpm publish` uses) and fails if
+ *      any dependency field in the packed manifest still carries a
+ *      `workspace:`, `link:`, or `file:` protocol. A correctly published
+ *      tarball has none; a `workspace:*` that survives is exactly what npm
+ *      rejects with EUNSUPPORTEDPROTOCOL.
+ *
+ *   2. Clean-room install — installs the packed tarball into a throwaway
+ *      project with the *npm* client (no workspace, no overrides), exactly as
+ *      an end user would. Catches EUNSUPPORTEDPROTOCOL and unresolvable (e.g.
+ *      unpublished) @zubridge/* runtime deps.
+ *
+ * Requires the packages to be built first (dist must exist). Wired into CI's
+ * Code Quality job.
+ *
+ * Usage: tsx scripts/check-publishable.ts
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const PACKAGES_DIR = path.join(ROOT, 'packages');
+const DEP_FIELDS = ['dependencies', 'peerDependencies', 'optionalDependencies', 'devDependencies'];
+const FORBIDDEN_PROTOCOL = /^(workspace|link|file):/;
+
+// Packages exercised with a real npm install. Limited to those expected to have
+// no unpublished cross-package runtime deps (electron bundles @zubridge/utils).
+const INSTALL_SMOKE = ['@zubridge/electron'];
+
+type PackedPackage = {
+  name: string;
+  tarball: string;
+  manifest: Record<string, unknown>;
+};
+
+function run(file: string, args: string[], cwd: string): string {
+  return execFileSync(file, args, { cwd, encoding: 'utf-8' }).toString();
+}
+
+function firstLine(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const stderr = (error as { stderr?: string }).stderr ?? '';
+  const text = (stderr.trim() || message).trim();
+  return text.split('\n')[0] ?? text;
+}
+
+function findPublishablePackages(): { name: string; dir: string }[] {
+  const result: { name: string; dir: string }[] = [];
+  for (const entry of fs.readdirSync(PACKAGES_DIR)) {
+    const dir = path.join(PACKAGES_DIR, entry);
+    const pkgJsonPath = path.join(dir, 'package.json');
+    if (!fs.existsSync(pkgJsonPath)) continue;
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+    if (pkg.name && !pkg.private) {
+      result.push({ name: pkg.name, dir });
+    }
+  }
+  return result;
+}
+
+function packPackage(dir: string, dest: string): string {
+  run('pnpm', ['pack', '--pack-destination', dest], dir);
+  const tarballs = fs.readdirSync(dest).filter((f) => f.endsWith('.tgz'));
+  const tarball = tarballs[0];
+  if (!tarball) {
+    throw new Error(`pnpm pack produced no tarball for ${dir}`);
+  }
+  return path.join(dest, tarball);
+}
+
+function readManifestFromTarball(tarball: string): Record<string, unknown> {
+  return JSON.parse(run('tar', ['-xzOf', tarball, 'package/package.json'], ROOT));
+}
+
+function lintManifest(pkg: PackedPackage): string[] {
+  const violations: string[] = [];
+  for (const field of DEP_FIELDS) {
+    const deps = pkg.manifest[field];
+    if (!deps || typeof deps !== 'object') continue;
+    for (const [name, spec] of Object.entries(deps as Record<string, string>)) {
+      if (typeof spec === 'string' && FORBIDDEN_PROTOCOL.test(spec)) {
+        violations.push(`${pkg.name}: ${field}.${name} = "${spec}"`);
+      }
+    }
+  }
+  return violations;
+}
+
+function installSmoke(tarball: string): void {
+  const smokeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zubridge-install-smoke-'));
+  try {
+    fs.writeFileSync(
+      path.join(smokeDir, 'package.json'),
+      JSON.stringify({ name: 'install-smoke', version: '0.0.0', private: true }, null, 2),
+    );
+    // npm is the client end users use and the one that rejects `workspace:`.
+    // --omit=peer skips the heavy electron/redux peer frameworks; the
+    // dependency-tree resolution where #194 failed still runs.
+    run(
+      'npm',
+      [
+        'install',
+        tarball,
+        '--omit=peer',
+        '--omit=optional',
+        '--no-audit',
+        '--no-fund',
+        '--no-save',
+      ],
+      smokeDir,
+    );
+  } finally {
+    fs.rmSync(smokeDir, { recursive: true, force: true });
+  }
+}
+
+function main(): void {
+  const packRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zubridge-pack-'));
+  const packages = findPublishablePackages();
+  const packed: PackedPackage[] = [];
+  const violations: string[] = [];
+
+  console.log(`Checking publishability of ${packages.length} package(s)...\n`);
+
+  try {
+    for (const { name, dir } of packages) {
+      const dest = fs.mkdtempSync(path.join(packRoot, 'pkg-'));
+      try {
+        const tarball = packPackage(dir, dest);
+        const manifest = readManifestFromTarball(tarball);
+        const pkg: PackedPackage = { name, tarball, manifest };
+        packed.push(pkg);
+
+        const found = lintManifest(pkg);
+        if (found.length > 0) {
+          violations.push(...found);
+          console.log(`  ✗ ${name}: forbidden dependency protocol in packed manifest`);
+        } else {
+          console.log(`  ✓ ${name}: no forbidden dependency protocols`);
+        }
+      } catch (error) {
+        violations.push(`${name}: failed to pack — ${firstLine(error)}`);
+        console.log(`  ✗ ${name}: failed to pack`);
+      }
+    }
+
+    console.log('');
+
+    for (const pkg of packed) {
+      if (!INSTALL_SMOKE.includes(pkg.name)) continue;
+      try {
+        installSmoke(pkg.tarball);
+        console.log(`  ✓ ${pkg.name}: clean npm install succeeds`);
+      } catch (error) {
+        violations.push(`${pkg.name}: clean npm install failed — ${firstLine(error)}`);
+        console.log(`  ✗ ${pkg.name}: clean npm install failed`);
+      }
+    }
+
+    if (violations.length > 0) {
+      console.error('\n❌ Publishability check failed:\n');
+      for (const v of violations) {
+        console.error(`  • ${v}`);
+      }
+      console.error(
+        '\nA packed manifest must not contain workspace:/link:/file: protocols, and public\n' +
+          'packages must install cleanly with npm. See issue #194.',
+      );
+      process.exit(1);
+    }
+
+    console.log('\n✅ All publishable packages passed.');
+  } finally {
+    fs.rmSync(packRoot, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/scripts/check-publishable.ts
+++ b/scripts/check-publishable.ts
@@ -1,28 +1,13 @@
 #!/usr/bin/env node
 
 /**
- * Publishability guard for the workspace's public packages.
+ * Fails the build if a public package would not install cleanly from npm for an
+ * end user. The package E2E harness can't catch this: it installs local tarballs
+ * with pnpm behind `pnpm.overrides`, so neither registry resolution nor the npm
+ * client is ever exercised — which is how issue #194 shipped (a `workspace:`
+ * spec that npm rejects with EUNSUPPORTEDPROTOCOL but pnpm tolerates).
  *
- * Reproduces the two failure modes behind issue #194, neither of which the
- * package E2E harness (run-package-e2e.ts) can catch: it installs from local
- * tarballs, uses pnpm (which tolerates the `workspace:` protocol), and
- * overrides every @zubridge/* dependency to a local file.
- *
- *   1. Protocol lint — packs each publishable package with `pnpm pack` (the
- *      same workspace-protocol rewrite path `pnpm publish` uses) and fails if
- *      any dependency field in the packed manifest still carries a
- *      `workspace:`, `link:`, or `file:` protocol. A correctly published
- *      tarball has none; a `workspace:*` that survives is exactly what npm
- *      rejects with EUNSUPPORTEDPROTOCOL.
- *
- *   2. Clean-room install — installs the packed tarball into a throwaway
- *      project with the *npm* client (no workspace, no overrides), exactly as
- *      an end user would. Catches EUNSUPPORTEDPROTOCOL and unresolvable (e.g.
- *      unpublished) @zubridge/* runtime deps.
- *
- * Requires the packages to be built first (dist must exist). Wired into CI's
- * Code Quality job.
- *
+ * Packages must be built first (dist must exist).
  * Usage: tsx scripts/check-publishable.ts
  */
 
@@ -106,9 +91,9 @@ function installSmoke(tarball: string): void {
       path.join(smokeDir, 'package.json'),
       JSON.stringify({ name: 'install-smoke', version: '0.0.0', private: true }, null, 2),
     );
-    // npm is the client end users use and the one that rejects `workspace:`.
-    // --omit=peer skips the heavy electron/redux peer frameworks; the
-    // dependency-tree resolution where #194 failed still runs.
+    // npm (not pnpm) is what rejects `workspace:`, so it must be the client here.
+    // --omit=peer skips the heavy electron/redux peer frameworks; the dependency
+    // resolution that fails on a bad spec still runs.
     run(
       'npm',
       [

--- a/scripts/run-package-e2e.ts
+++ b/scripts/run-package-e2e.ts
@@ -51,8 +51,11 @@ if (specificApp && !targetApp) {
 // Constants
 const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
 const TEMP_DIR = path.join(os.tmpdir(), `zubridge-e2e-${Date.now()}`);
+// @zubridge/utils is intentionally absent: it is bundled into @zubridge/electron's
+// dist at build time (noExternal in tsdown.config.ts), so it is not a runtime
+// dependency and must not be installed/resolved separately. See issue #194.
 const ZUBRIDGE_PACKAGES = {
-  dependencies: ['@zubridge/utils', '@zubridge/electron'],
+  dependencies: ['@zubridge/electron'],
   devDependencies: ['@zubridge/types'],
 };
 


### PR DESCRIPTION
## Problem

`npm install @zubridge/electron` fails with `EUNSUPPORTEDPROTOCOL` (issue #194). The published `@zubridge/electron@3.0.0` manifest carries `"@zubridge/core": "workspace:*"` — a pnpm-only protocol that npm can't resolve.

**Root cause** (historical): 3.0.0 was published by the now-retired bespoke `scripts/publish.ts`, whose OIDC branch used `npm publish` (does **not** rewrite `workspace:`) instead of `pnpm publish` (does). Releasekit — the current publisher — uses `pnpm publish`, so the publish path is already structurally fixed. But the dependency was also spurious to begin with.

## Fix

`@zubridge/utils` is **bundled** into electron's `dist` via tsdown `noExternal` (all entry points) and is imported nowhere at runtime — so it was never a real runtime dependency.

- Move `@zubridge/utils` from `dependencies` → `devDependencies` (matching how `@zubridge/types` is already handled). Published electron now has **zero `@zubridge/*` runtime deps**, so it installs with no workspace-scope resolution at all — robust even if a `workspace:` string ever leaks again (npm ignores devDeps of installed packages).
- Remove the orphaned `@types/debug` dependency — no `debug` import remains in electron's source (the debug system lives in `@zubridge/utils` via `weald`). Forward-looking cleanup tracked in #195.

## Regression guard

The package E2E harness can't catch this: it installs local tarballs with pnpm behind `pnpm.overrides`, masking registry/protocol problems.

- **`scripts/check-publishable.ts`** (`pnpm run check:publishable`): packs each public package with `pnpm pack` and fails on any `workspace:`/`link:`/`file:` protocol in the packed manifest, then does a clean-room `npm install` of the electron tarball with the **npm** client — the exact path that failed in #194.
- Wired into CI's **Code Quality** job.
- `run-package-e2e.ts` no longer treats `@zubridge/utils` as a runtime dep.

## Verification

- `pnpm run check:publishable` — all 5 public packages pass; electron `npm install` succeeds.
- Packed electron manifest: no `@zubridge/*` runtime deps, no `@types/debug`.
- electron typecheck clean; **1070** unit tests pass.
- Guard confirmed to catch `workspace:`/`link:`/`file:` protocols.

## Follow-up (not in this PR)

- Cut **3.0.1** (releasekit `scope: electron`, patch, stable).
- `npm deprecate @zubridge/electron@3.0.0` once 3.0.1 is verified from the registry.
- #195 — adopt `weald` as a first-class dep, drop `debug`/`@types/debug`.

Fixes #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPTAY2SwM1NFFfYHdga9FG

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Electron package install problem for npm users. The main changes are:

- Moves `@zubridge/utils` out of Electron runtime dependencies.
- Removes the unused `@types/debug` dependency from Electron.
- Adds a publishability check for packed manifests and npm install smoke testing.
- Wires the publishability check into CI.
- Updates the package E2E harness to match the bundled Electron runtime dependency model.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-publishable.ts | Adds a guard that packs public packages, scans packed manifests, and smoke-tests installing the Electron tarball with npm. |
| packages/electron/package.json | Moves `@zubridge/utils` to dev dependencies and removes the unused debug types dependency. |
| scripts/run-package-e2e.ts | Stops installing `@zubridge/utils` as a separate runtime package in package E2E setup. |
| .github/workflows/ci.yml | Runs the new publishability check in the Code Quality CI job. |
| package.json | Adds the root `check:publishable` script. |
| pnpm-lock.yaml | Updates the lockfile for the Electron dependency classification change. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(electron): trim check-publishable ..."](https://github.com/goosewobbler/zubridge/commit/6985c283036022194eef9c71cad6cf5458a1ffda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43633476)</sub>

<!-- /greptile_comment -->