### PR TITLE
ci(release): fix reusable-workflow permissions + make standing-PR reconcile unconditional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,11 +60,6 @@ on:
         required: false
         type: string
         default: ''
-      reconcile_after:
-        description: 'Rebuild the standing release PR after this release completes. Manual callers may enable it so the standing PR drops the just-released changes.'
-        required: false
-        type: boolean
-        default: false
 
 concurrency:
   group: release
@@ -176,10 +171,14 @@ jobs:
       crates_io_token: ${{ secrets.CRATES_IO_TOKEN }}
       ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
 
+  # Always reconcile after a real manual release: releasekit does not auto-rebuild
+  # the standing PR, and the `chore: release` commit suppresses the push-triggered
+  # update, so skipping this leaves the standing PR listing already-published
+  # versions. Mirrors reconcile-after-auto. Skipped only on dry runs.
   reconcile-after-manual:
     name: Reconcile standing PR
     needs: [release-manual]
-    if: github.event_name == 'workflow_dispatch' && inputs.reconcile_after && !inputs.dry_run && needs.release-manual.result == 'success'
+    if: github.event_name == 'workflow_dispatch' && !inputs.dry_run && needs.release-manual.result == 'success'
     uses: ./.github/workflows/_standing-pr-update.reusable.yml
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,10 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      # _release.reusable.yml declares pull-requests: write at its top level, so
+      # every caller must grant at least that or the workflow fails validation.
+      # Unused on this path (only the standing-pr publish path touches PRs).
+      pull-requests: write
     with:
       target_branch: main
       bump: ${{ needs.gate.outputs.bump }}
@@ -157,6 +161,10 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      # _release.reusable.yml declares pull-requests: write at its top level, so
+      # every caller must grant at least that or the workflow fails validation.
+      # Unused on this path (only the standing-pr publish path touches PRs).
+      pull-requests: write
     with:
       target_branch: ${{ inputs.target_branch }}
       bump: ${{ inputs.bump }}


### PR DESCRIPTION
Two `release.yml` fixes.

## 1. Reusable-workflow permissions (the blocker)

Triggering `release.yml` (e.g. a dry-run manual release) failed at validation before any job ran:

```
Invalid workflow file: .github/workflows/release.yml#L115
Error calling workflow '_release.reusable.yml'. The workflow is requesting
'pull-requests: write', but is only allowed 'pull-requests: none'.
```

`_release.reusable.yml` declares `pull-requests: write` at its top level, so **every** caller must grant it. Only `release-standing-pr` did — `release-auto` and `release-manual` declared a `permissions:` block with `contents`/`id-token` only, and once a job specifies a permissions block every unlisted scope is capped at `none`. The manual path (used by dry runs) therefore couldn't load.

Grant `pull-requests: write` to `release-auto` and `release-manual`. Audited every reusable-workflow caller in the repo — the `reconcile-after-*` jobs, `standing-pr.yml`, and the `build-and-test.yml` test jobs are already correct; these two were the only gap.

## 2. Drop the `reconcile_after` checkbox; always reconcile after a manual release

Verified against releasekit 0.41.1 source: it does **not** auto-rebuild the standing PR after a publish. The standing-PR reconcile is a deliberate, separate step (`standing-pr update --reconcile`) that releasekit treats as **mandatory** after a manual/bypass release (its canonical template always runs it, no toggle).

So gating it behind an opt-in `reconcile_after` checkbox (default `false`) was a footgun: a manual release that forgot to tick it would leave the standing PR listing already-published versions (the `chore: release` commit also suppresses the normal push-triggered update).

- Remove the `reconcile_after` input.
- Run `reconcile-after-manual` unconditionally after a successful non-dry-run manual release, matching `reconcile-after-auto` / `reconcile-after-standing-pr`.

**Kept `standing_pr_number`** (the other input queried): releasekit auto-resolves the merged PR (event payload → API fallback, since v0.24.0), but it explicitly prefers an explicit `--pr` for dispatch-funnelled workflows to guard against a stale re-run picking up a newer merged PR — and it also serves as this workflow's manual-vs-standing-PR path discriminator. Removing it would forfeit both.

## Verification

- `actionlint .github/workflows/release.yml` passes.
- All three `_release.reusable.yml` callers now grant `contents`/`id-token`/`pull-requests` write.
- No `reconcile_after` references remain; `standing_pr_number` intact on both paths.

After merge, re-run the `release.yml` dry-run (scope `electron`, patch, stable) — it should validate and execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPTAY2SwM1NFFfYHdga9FG

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the release workflow permissions and manual reconciliation behavior. The main changes are:

- Grants `pull-requests: write` to automatic and manual release jobs.
- Removes the optional `reconcile_after` dispatch input.
- Rebuilds the standing release PR after successful non-dry-run manual releases.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The added permissions match the reusable release workflow's requirements.
- No blocking issue was found in the updated workflow paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Updates reusable-workflow permissions and makes standing-PR reconciliation automatic after real manual releases. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci(release): make manual-release reconci..."](https://github.com/goosewobbler/zubridge/commit/cd794afd2a5737ccf5c0b2c5426162ad2768088f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45805931)</sub>

<!-- /greptile_comment -->