### PR TITLE
fix(electron): bundle weald into main/preload so debug works in the published package

### DIFF
--- a/packages/electron/tsdown.config.ts
+++ b/packages/electron/tsdown.config.ts
@@ -55,8 +55,12 @@ export default defineConfig([
     entry: ['src/main.ts'],
     format: ['esm', 'cjs'],
     dts: true,
-    external: ['electron', 'zustand', 'zustand/vanilla', 'weald', '@wdio/logger'],
-    noExternal: ['@zubridge/utils'],
+    external: ['electron', 'zustand', 'zustand/vanilla', '@wdio/logger'],
+    // weald is bundled (not external): it's the production debug backend and is not a
+    // declared runtime dependency, so leaving it external makes the import fail in a
+    // consumer's app and debug silently falls back to console. @wdio/logger stays external
+    // — it's only loaded in WDIO E2E, where it's installed.
+    noExternal: ['@zubridge/utils', 'weald'],
     outDir: 'dist',
     clean: false,
     sourcemap: false,
@@ -80,9 +84,9 @@ export default defineConfig([
     dts: true,
     external: (id) => {
       if (externalizeUnenvRuntime(id)) return true;
-      return ['electron', 'zustand', 'zustand/vanilla', 'weald', '@wdio/logger'].includes(id);
+      return ['electron', 'zustand', 'zustand/vanilla', '@wdio/logger'].includes(id);
     },
-    noExternal: ['@zubridge/utils'],
+    noExternal: ['@zubridge/utils', 'weald'],
     outDir: 'dist',
     clean: false,
     sourcemap: false,

--- a/packages/electron/tsdown.win32.preload.config.ts
+++ b/packages/electron/tsdown.win32.preload.config.ts
@@ -18,9 +18,9 @@ export default defineConfig({
   dts: true,
   external: (id) => {
     if (externalizeUnenvRuntime(id)) return true;
-    return ['electron', 'zustand', 'zustand/vanilla', 'weald', '@wdio/logger'].includes(id);
+    return ['electron', 'zustand', 'zustand/vanilla', '@wdio/logger'].includes(id);
   },
-  noExternal: ['@zubridge/utils'],
+  noExternal: ['@zubridge/utils', 'weald'],
   outDir: 'dist',
   clean: false,
   sourcemap: false,


### PR DESCRIPTION
## Problem

The debug system (`@zubridge/utils/debug.ts`) uses **weald** as its production backend via a dynamic `import('weald')`. In the **main** and **preload** builds weald was marked `external`, but it is **not** a declared runtime dependency of `@zubridge/electron`. So in a consumer's installed app:

- `main.js` / `preload.js` → `import('weald')` fails → debug silently falls back to `console.log` (loses weald's namespace filtering/formatting).
- `renderer.js` → already bundles weald (`noExternal`) → uses it properly.

Net: inconsistent debug output, and `DEBUG=zubridge:*` in a consumer's main process never gets weald handling. Pre-existing since 3.0.0 (not a regression), surfaced while scoping the 3.1.0 release.

## Fix

Move `weald` from `external` → `noExternal` in the cross-platform main/preload configs and the win32 preload config — matching the renderer and win32-node configs, which already bundle it. `@wdio/logger` stays external (only loaded under WDIO E2E, where it's installed).

## Verification

- `dist/{main,preload}.{js,cjs}` — **0** external `import('weald')`/`require('weald')` refs after build; weald source is now inlined.
- `@wdio/logger` still external (WDIO-only). ✓
- Packed manifest `dependencies` unchanged — no `weald`, no `@zubridge/*` runtime dep (weald is bundled, not a dep).
- electron typecheck clean.

## Scope

Carve-out of the debug portion of #195. The full weald adoption (drop `debug`/`@types/debug`, first-class weald with native types) remains tracked in #195. Release content for 3.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPTAY2SwM1NFFfYHdga9FG

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bundles the production debug backend into Electron’s published main and preload outputs. The main changes are:

- Move `weald` from `external` to `noExternal` in the cross-platform main build.
- Apply the same change to cross-platform and Win32 preload builds.
- Keep Electron, Zustand, and `@wdio/logger` external.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The affected configurations consistently bundle `weald` while retaining the intended runtime externals.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/electron/tsdown.config.ts | Bundles `weald` into the cross-platform main and preload outputs while preserving the other external package settings. |
| packages/electron/tsdown.win32.preload.config.ts | Bundles `weald` into the Win32 preload output without changing its other build options. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(electron): bundle weald into main/pr..."](https://github.com/goosewobbler/zubridge/commit/4c5feb667404fb5ae7698b2b7d8181f8231814dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46423867)</sub>

<!-- /greptile_comment -->