### PR TITLE
ci(release): group @zubridge/tauri + tauri-plugin-zubridge as an independent set

### DIFF
--- a/releasekit.config.jsonc
+++ b/releasekit.config.jsonc
@@ -19,6 +19,21 @@
     "prereleaseIdentifier": "next",
     "packageSpecificTags": true,
     "mismatchStrategy": "prefer-package",
+    // @zubridge/tauri (npm) + tauri-plugin-zubridge (cargo) share a wire protocol and must
+    // ship together. `independent` keeps them on separate commit-driven version lines but
+    // releases the set atomically — targeting either pulls in the other, so a Tauri-TS-only
+    // change can't publish an npm release whose crate half is stale. This enforces the
+    // coupling on the standing-PR accumulation path; scopeLabels below only couples them
+    // when a scope:tauri feeder PR is the trigger.
+    "groups": {
+      "tauri": {
+        "packages": [
+          "@zubridge/tauri",
+          "tauri-plugin-zubridge"
+        ],
+        "sync": "independent"
+      }
+    },
     "cargo": {
       "enabled": true
     },


### PR DESCRIPTION
Surfaced by the releasekit-usage audit (companion to #203).

## Problem

`@zubridge/tauri` (npm) and `tauri-plugin-zubridge` (cargo) share a wire protocol and must release together — the config already says so. But that coupling is only enforced on the `scope:tauri` **feeder-PR label** path (`ci.scopeLabels`). Under the **standing-PR accumulation flow** (the primary path for `releaseStrategy: standing-pr`), releasekit auto-detects changed packages by path: a PR touching only the Tauri TypeScript queues `@zubridge/tauri` **without** pulling in the crate → an npm release whose cargo half is stale. The crate isn't an npm dependency of `@zubridge/tauri`, so releasekit's prerequisite mechanism won't link them either — only a version group does.

## Fix

Add `version.groups.tauri` with `sync: "independent"`: members keep separate commit-driven version lines, but the set ships **atomically** (targeting either pulls in the other). Mirrors wdio-desktop-mobile's `version.groups.tauri`. Compatible with the existing `version.sync: false`.

**No effect on scoped single-package releases** (e.g. the electron 3.1.0 release) — it only changes what the *Tauri* release pulls in. Separated from #203 because it changes release behavior and warranted its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPTAY2SwM1NFFfYHdga9FG

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR couples the Tauri npm package and Rust crate in the standing release flow. The main changes are:

- Adds an independent Tauri version group.
- Selects both Tauri packages for an atomic release.
- Keeps separate commit-driven version lines.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| releasekit.config.jsonc | Adds an independent release group for the matching Tauri npm package and Cargo crate. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci(release): group @zubridge/tauri + tau..."](https://github.com/goosewobbler/zubridge/commit/cc7ac1e521e26d261cdca86d25aeed4377bdf414) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46429767)</sub>

<!-- /greptile_comment -->