### PR TITLE
chore(scripts): link #194 as full URLs in comments

### DIFF
--- a/scripts/check-publishable.ts
+++ b/scripts/check-publishable.ts
@@ -4,8 +4,10 @@
  * Fails the build if a public package would not install cleanly from npm for an
  * end user. The package E2E harness can't catch this: it installs local tarballs
  * with pnpm behind `pnpm.overrides`, so neither registry resolution nor the npm
- * client is ever exercised — which is how issue #194 shipped (a `workspace:`
- * spec that npm rejects with EUNSUPPORTEDPROTOCOL but pnpm tolerates).
+ * client is ever exercised — which is how the bug shipped: a `workspace:` spec
+ * that npm rejects with EUNSUPPORTEDPROTOCOL but pnpm tolerates.
+ *
+ * See https://github.com/goosewobbler/zubridge/issues/194
  *
  * Packages must be built first (dist must exist).
  * Usage: tsx scripts/check-publishable.ts
@@ -162,7 +164,8 @@ function main(): void {
       }
       console.error(
         '\nA packed manifest must not contain workspace:/link:/file: protocols, and public\n' +
-          'packages must install cleanly with npm. See issue #194.',
+          'packages must install cleanly with npm.\n' +
+          'See https://github.com/goosewobbler/zubridge/issues/194',
       );
       process.exit(1);
     }

--- a/scripts/run-package-e2e.ts
+++ b/scripts/run-package-e2e.ts
@@ -53,7 +53,8 @@ const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
 const TEMP_DIR = path.join(os.tmpdir(), `zubridge-e2e-${Date.now()}`);
 // @zubridge/utils is intentionally absent: it is bundled into @zubridge/electron's
 // dist at build time (noExternal in tsdown.config.ts), so it is not a runtime
-// dependency and must not be installed/resolved separately. See issue #194.
+// dependency and must not be installed/resolved separately.
+// See https://github.com/goosewobbler/zubridge/issues/194
 const ZUBRIDGE_PACKAGES = {
   dependencies: ['@zubridge/electron'],
   devDependencies: ['@zubridge/types'],


### PR DESCRIPTION
Follow-up to the review-comment convention: replace bare `#194` refs in `scripts/check-publishable.ts` (docstring + failure message) and `scripts/run-package-e2e.ts` with full `https://github.com/goosewobbler/zubridge/issues/194` links — clickable and unambiguous rather than repo-context-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPTAY2SwM1NFFfYHdga9FG

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces abbreviated issue references with a full GitHub URL.

- Updates the publishability script documentation and failure message.
- Updates the package E2E script comment.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-publishable.ts | Uses the full issue URL in documentation and stderr output without changing control flow or exit behavior. |
| scripts/run-package-e2e.ts | Uses the full issue URL in a source comment with no runtime change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(scripts): link the #194 issue as f..."](https://github.com/goosewobbler/zubridge/commit/e497aef010aeb9bc596aca9f24f5476ced08df95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46433239)</sub>

<!-- /greptile_comment -->